### PR TITLE
more flexible policy and drift source scan

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,6 +12,7 @@ setup(
         "toolz",
         "pandas",
         "chex",
-        "pyephem"
+        "pyephem",
+        "equinox"
     ],
 )

--- a/setup.py
+++ b/setup.py
@@ -13,6 +13,7 @@ setup(
         "pandas",
         "chex",
         "pyephem",
-        "equinox"
+        "equinox",
+        "so3g"
     ],
 )

--- a/src/schedlib/config.py
+++ b/src/schedlib/config.py
@@ -1,0 +1,14 @@
+from . import utils
+import yaml
+
+def datetime_constructor(loader, node):
+    """load a datetime"""
+    return utils.str2datetime(loader.construct_scalar(node))
+
+def get_loader():
+    # add some useful tags to the loader 
+    loader = yaml.SafeLoader
+    loader.add_constructor('!datetime', datetime_constructor)
+    # ignore unknown tags
+    loader.add_multi_constructor('!', lambda loader, tag_suffix, node: None)
+    return loader

--- a/src/schedlib/core.py
+++ b/src/schedlib/core.py
@@ -5,7 +5,8 @@ import numpy as np
 import jax.tree_util as tu
 import equinox
 from dataclasses import dataclass, replace as dc_replace
-import fnmatch
+
+from . import utils
 
 @dataclass(frozen=True)
 class Block:
@@ -267,14 +268,7 @@ def seq_partition_with_query(query, blocks: BlocksTree):
             else:
                 raise ValueError(f"unknown path type {type(p)}")
         return ".".join([str(k) for k in keys])
-    # TODO: support comma separated list of queries
-    def match_query(path, block):
-        key = path2key(path)
-        # first match the constraint to key
-        if query in key: return True
-        # then match based on fnmatch pattern
-        return fnmatch.fnmatch(path2key(path), query)
-    return seq_partition_with_path(match_query, blocks)
+    return seq_partition_with_path(lambda path, block: utils.match_query(path, query), blocks)
 
 def seq_combine(*blocks: BlocksTree) -> BlocksTree:
     """combine blocks from multiple trees into a single tree, where the blocks are

--- a/src/schedlib/core.py
+++ b/src/schedlib/core.py
@@ -1,10 +1,9 @@
 from typing import List, Union, Callable, Optional, Any, TypeVar
-from chex import dataclass
 from abc import ABC, abstractmethod
 import datetime as dt
 import numpy as np
-from toolz import compose_left
 import jax.tree_util as tu
+from dataclasses import dataclass, replace as dc_replace
 
 @dataclass(frozen=True)
 class Block:
@@ -37,6 +36,8 @@ class Block:
         return block_trim_right_to(self, t)
     def isa(self, block_type: "BlockType") -> bool:
         return block_isa(block_type)(self)
+    def replace(self, **kwargs) -> "Block":
+        return dc_replace(self, **kwargs)
 
 BlockType = type(Block)
 Blocks = List[Union[Block, None, "Blocks"]]  # maybe None, maybe nested
@@ -255,14 +256,6 @@ class BlocksTransformation(ABC):
 
 Rule = Union[BlocksTransformation, Callable[[Blocks], Blocks]]
 RuleSet = List[Rule]
-
-@dataclass(frozen=True)
-class MultiRules(BlocksTransformation):
-    rules: RuleSet
-    def apply(self, blocks: Blocks) -> Blocks:
-        """apply rules to blocks in first-to-last order"""
-        return compose_left(*self.rules)(blocks)
-
 
 @dataclass(frozen=True)
 class Policy(BlocksTransformation, ABC):

--- a/src/schedlib/instrument.py
+++ b/src/schedlib/instrument.py
@@ -1,9 +1,9 @@
 from __future__ import annotations
-from chex import dataclass
 from jax import tree_util as tu
 from typing import List, TypeVar, Union, Dict
 import numpy as np
 from functools import reduce
+from dataclasses import dataclass
 
 from . import core
 

--- a/src/schedlib/instrument.py
+++ b/src/schedlib/instrument.py
@@ -5,7 +5,7 @@ import numpy as np
 from functools import reduce
 from dataclasses import dataclass
 
-from . import core
+from . import core, utils
 
 @dataclass(frozen=True)
 class ScanBlock(core.NamedBlock):
@@ -35,14 +35,13 @@ def get_spec(specs: SpecsTree, query: List[str], merge=True) -> Union[Spec, Spec
     one of the queries. return all matches if merge=False"""
     is_leaf = lambda x: isinstance(x, dict) and 'bounds_x' in x
     match_p = lambda key: any([p in key for p in query])
-    path2key = lambda path: ".".join([str(p.key) for p in path])
     def reduce_fn(l, r):
         res = {}
         for k in ['bounds_x', 'bounds_y']:
             res[k] = [min(l[k][0], r[k][0]), max(l[k][1], r[k][1])]
         return res
     all_matches = tu.tree_leaves(
-        tu.tree_map_with_path(lambda path, x: x if match_p(path2key(path)) else None, specs, is_leaf=is_leaf), 
+        tu.tree_map_with_path(lambda path, x: x if match_p(utils.path2key(path)) else None, specs, is_leaf=is_leaf), 
         is_leaf=is_leaf
     )  # None is not a leaf, so it will be filtered out
     if not merge: return all_matches

--- a/src/schedlib/instrument.py
+++ b/src/schedlib/instrument.py
@@ -1,17 +1,20 @@
 from __future__ import annotations
 from jax import tree_util as tu
+import pandas as pd
 from typing import List, TypeVar, Union, Dict
 import numpy as np
 from functools import reduce
 from dataclasses import dataclass
+from so3g.proj import quat
 
-from . import core, utils
+from . import core, utils as u
 
 @dataclass(frozen=True)
 class ScanBlock(core.NamedBlock):
-    az: float     # deg
-    alt: float    # deg
-    throw: float  # deg
+    az: float        # deg
+    alt: float       # deg
+    throw: float     # deg
+    drift: float = 0 # deg / s
 
 @dataclass(frozen=True)
 class IVBlock(core.NamedBlock): pass
@@ -41,7 +44,7 @@ def get_spec(specs: SpecsTree, query: List[str], merge=True) -> Union[Spec, Spec
             res[k] = [min(l[k][0], r[k][0]), max(l[k][1], r[k][1])]
         return res
     all_matches = tu.tree_leaves(
-        tu.tree_map_with_path(lambda path, x: x if match_p(utils.path2key(path)) else None, specs, is_leaf=is_leaf), 
+        tu.tree_map_with_path(lambda path, x: x if match_p(u.path2key(path)) else None, specs, is_leaf=is_leaf), 
         is_leaf=is_leaf
     )  # None is not a leaf, so it will be filtered out
     if not merge: return all_matches
@@ -54,10 +57,62 @@ def get_bounds_x_tilted(bounds_x: List[float], bounds_y: List[float], phi_tilt: 
     a = (bounds_x[1] - bounds_x[0])/2
     b = (bounds_y[1] - bounds_y[0])/2
     if shape == 'ellipse':
-        # w_proj = np.sqrt(a**2 * np.cos(phi_tilt)**2 + b**2 * np.sin(phi_tilt)**2) # TODO: double check this is missing 1/sin(phi)
-        w_proj = a * np.sqrt(1 + b**2 / a**2 * np.tan(phi_tilt)**2)  # TODO: double-check this is correct
+        w_proj = a * np.sqrt(1 + b**2 / a**2 * np.tan(phi_tilt)**2)
     elif shape == 'rect':
         w_proj = b * np.tan(phi_tilt) + a
     else:
         raise NotImplementedError
     return np.array([-w_proj, w_proj]) + (bounds_x[0] + bounds_x[1])/2
+
+def make_circular_cover(xi0, eta0, R, count=50, degree=True):
+    """make a circular cover centered at xi0, eta0 with radius R"""
+    if degree: xi0, eta0, R = np.deg2rad([xi0, eta0, R])
+    dphi = 2*np.pi/count
+    phi = np.arange(count) * dphi
+    L = 1.01*R / np.cos(dphi/2)
+    xi, eta = L * np.cos(phi), L * np.sin(phi)
+    xi, eta, _ = quat.decompose_xieta(quat.rotation_xieta(xi0, eta0) * quat.rotation_xieta(xi, eta))
+    return {
+        'center': (xi0, eta0),
+        'cover': np.array([xi, eta])
+    }
+
+def array_info_merge(arrays):
+    center = np.mean(np.array([a['center'] for a in arrays]), axis=0)
+    cover = np.concatenate([a['cover'] for a in arrays], axis=1)
+    return {
+        'center': center,
+        'cover': cover
+    }
+
+def array_info_from_query(geometries, query):
+    """make an array info with geometries that match the query"""
+    is_leaf = lambda x: isinstance(x, dict) and 'center' in x
+    matched = tu.tree_leaves(tu.tree_map_with_path(
+        lambda path, x: x if u.match_query(path, query) else None,
+        geometries,
+        is_leaf=is_leaf
+    ), is_leaf=is_leaf)
+    arrays = [make_circular_cover(*g['center'], g['radius']) for g in matched]
+    return array_info_merge(arrays)
+
+def parse_sequence_from_toast(ifile):
+    """
+    Parameters
+    ----------
+    ifile: input master schedule from toast
+    """
+    columns = ["start_utc", "stop_utc", "rotation", "patch", "az_min", "az_max", "el", "pass", "sub"]
+    df = pd.read_csv(ifile, skiprows=3, delimiter="|", names=columns)
+    blocks = []
+    for _, row in df.iterrows():
+        block = ScanBlock(
+            name=row['patch'].strip(),
+            t0=u.str2datetime(row['start_utc']),
+            t1=u.str2datetime(row['stop_utc']),
+            alt=row['el'],
+            az=row['az_min'],
+            throw=np.abs(row['az_max'] - row['az_min']),
+        )
+        blocks.append(block)
+    return blocks

--- a/src/schedlib/instrument.py
+++ b/src/schedlib/instrument.py
@@ -50,11 +50,14 @@ def get_spec(specs: SpecsTree, query: List[str], merge=True) -> Union[Spec, Spec
 
 def get_bounds_x_tilted(bounds_x: List[float], bounds_y: List[float], phi_tilt: Union[float, core.Arr[float]], shape: str):
     """get the effective bounds of the x-axis of the spec when covering a tilted patch"""
-    assert shape in ['ellipse']  # more to implement
+    assert shape in ['ellipse', 'rect']  # more to implement
+    a = (bounds_x[1] - bounds_x[0])/2
+    b = (bounds_y[1] - bounds_y[0])/2
     if shape == 'ellipse':
-        a = (bounds_x[1] - bounds_x[0])/2
-        b = (bounds_y[1] - bounds_y[0])/2
-        w_proj = np.sqrt(a**2 * np.cos(phi_tilt)**2 + b**2 * np.sin(phi_tilt)**2)
-        return np.array([-w_proj, w_proj]) + (bounds_x[0] + bounds_x[1])/2
+        # w_proj = np.sqrt(a**2 * np.cos(phi_tilt)**2 + b**2 * np.sin(phi_tilt)**2) # TODO: double check this is missing 1/sin(phi)
+        w_proj = a * np.sqrt(1 + b**2 / a**2 * np.tan(phi_tilt)**2)  # TODO: double-check this is correct
+    elif shape == 'rect':
+        w_proj = b * np.tan(phi_tilt) + a
     else:
         raise NotImplementedError
+    return np.array([-w_proj, w_proj]) + (bounds_x[0] + bounds_x[1])/2

--- a/src/schedlib/policies/__init__.py
+++ b/src/schedlib/policies/__init__.py
@@ -1,0 +1,1 @@
+from .basic import BasePolicy, BasicPolicy

--- a/src/schedlib/policies/__init__.py
+++ b/src/schedlib/policies/__init__.py
@@ -1,1 +1,2 @@
 from .basic import BasePolicy, BasicPolicy
+from .flex import FlexPolicy

--- a/src/schedlib/policies/basic.py
+++ b/src/schedlib/policies/basic.py
@@ -48,7 +48,7 @@ class BasicPolicy(BasePolicy):
         return ru.make_rule(rule_name, **kwargs)
 
     def init_seqs(self, t0: dt.datetime, t1: dt.datetime) -> core.BlocksTree:
-        master = utils.parse_sequence_from_toast(self.master_schedule)
+        master = inst.parse_sequence_from_toast(self.master_schedule)
         calibration = {k: src.source_gen_seq(k, t0, t1) for k in self.calibration_targets}
         soft = {k: src.source_gen_seq(k, t0, t1) for k in self.soft_targets}
         blocks = {

--- a/src/schedlib/policies/flex.py
+++ b/src/schedlib/policies/flex.py
@@ -12,56 +12,69 @@ from .. import config as cfg, core, utils, source as src, rules as ru, commands 
 class FlexPolicy(basic.BasePolicy):
     """a flexible policy. `config` is a string yaml config *content*"""
     config_text: str
-    rules: List[core.Rule]
+    rules: List[dict]
     post_rules: List[core.Rule]
     merge_order: List[str]
+    geometries: List[dict]
 
-    @staticmethod
-    def rule_constructor(loader, node):
-        """loader for rule"""
-        kwargs = loader.construct_mapping(node)
-        rule_name = kwargs.pop('name')
-        constraint = kwargs.pop('constraint', None)
+    @classmethod
+    def make_rule(cls, rule_cfg, full_config={}):
+        rule_name = rule_cfg.pop('name')
+        constraint = rule_cfg.pop('constraint', None)
 
-        # some rules that require randomization
+        # rules that require randomization
         if rule_name in ['make-source-scan', 'rephase-first']:
             today = dt.datetime.now()
-            rng_key = utils.PRNGKey((today.year, today.month, today.day, kwargs.pop('seed', 0)))
-            kwargs['rng_key'] = rng_key
-        rule = ru.make_rule(rule_name, **kwargs)
+            rng_key = utils.PRNGKey((today.year, today.month, today.day, rule_cfg.pop('seed', 0)))
+            rule_cfg['rng_key'] = rng_key
+            rule = ru.make_rule(rule_name, **rule_cfg)
+        # treat special rule
+        elif rule_name == 'make-drift-scan':
+            rule_cfg['geometries'] = full_config['geometries']
+            rule = ru.MakeCESourceScan.from_config(rule_cfg)
+        else:
+            rule = ru.make_rule(rule_name, **rule_cfg)
 
         # if a constraint is specified, make a constrained rule instead.
         if constraint is not None:
-            return ru.ConstrainedRule(rule, constraint)
-        else:
-            return rule
+            rule = ru.ConstrainedRule(rule, constraint)
+        return rule
 
     @classmethod
     def from_config(cls, config: str):
         """populate policy object from a yaml config file"""
-        # first we load the text content of config into a string for
-        # later use
+        # load the text content of config into a string for later use
         if op.isfile(config):
             with open(config, "r") as f:
                 config_text = f.read()
         else:
             config_text = config
-        # then we pre-load the config to populate some common fields in
-        # the policy
+
+        # pre-load the config to populate some common fields in the policy
         loader = cfg.get_loader()
-        loader.add_constructor("!rule", cls.rule_constructor)
         config = yaml.load(config_text, Loader=loader)
+
+        # load rules
+        rules = []
+        for rule_cfg in config.pop('rules'):
+            rules.append(cls.make_rule(rule_cfg, full_config=config))
+
+        post_rules = []
+        for rule_cfg in config.pop('post_rules', []):
+            post_rules.append(cls.make_rule(rule_cfg, full_config=config))
+
         # remove fields that need special handling later on
         config.pop('blocks')
+
         # now we can construct the policy
-        return cls(config_text=config_text, **config)
+        return cls(config_text=config_text, rules=rules, post_rules=post_rules, **config)
 
     def init_seqs(self, t0: dt.datetime, t1: dt.datetime) -> core.BlocksTree:
         # prepare some specialized loaders: !source [source_name], !toast [toast schedule name]
         def source_constructor(t0, t1, loader, node):
             return src.source_gen_seq(loader.construct_scalar(node), t0, t1)
         def toast_constructor(loader, node):
-            return utils.parse_sequence_from_toast(loader.construct_scalar(node))
+            return inst.parse_sequence_from_toast(loader.construct_scalar(node))
         loader = cfg.get_loader()
         loader.add_constructor('!source', lambda loader, node: source_constructor(t0, t1, loader, node))
         loader.add_constructor('!toast', lambda loader, node: toast_constructor(loader, node))
@@ -73,15 +86,14 @@ class FlexPolicy(basic.BasePolicy):
         # apply each rule
         for rule in self.rules: 
             blocks = rule(blocks)
-
         return blocks
 
     def merge(self, blocks: core.BlocksTree) -> core.Blocks:
         """merge blocks into a single sequence by the order specified
-        in self.merge_order, assuming an ascending priority order as moving
+        in self.merge_order, assuming an descending priority order as moving
         down the merge_order list."""
         seq = None
-        for query in self.merge_order:
+        for query in self.merge_order[::-1]:
             match, _ = core.seq_partition_with_query(query, blocks)
             if seq is None: 
                 seq = match

--- a/src/schedlib/policies/flex.py
+++ b/src/schedlib/policies/flex.py
@@ -1,0 +1,116 @@
+import yaml
+import os.path as op
+from dataclasses import dataclass
+import datetime as dt
+from typing import List
+
+from . import basic
+from .. import config as cfg, core, utils, source as src, rules as ru, commands as cmd, instrument as inst
+
+
+@dataclass(frozen=True)
+class FlexPolicy(basic.BasePolicy):
+    """a flexible policy. `config` is a string yaml config *content*"""
+    config_text: str
+    rules: List[core.Rule]
+    post_rules: List[core.Rule]
+    merge_order: List[str]
+
+    @staticmethod
+    def rule_constructor(loader, node):
+        """loader for rule"""
+        kwargs = loader.construct_mapping(node)
+        rule_name = kwargs.pop('name')
+        constraint = kwargs.pop('constraint', None)
+
+        # some rules that require randomization
+        if rule_name in ['make-source-scan', 'rephase-first']:
+            today = dt.datetime.now()
+            rng_key = utils.PRNGKey((today.year, today.month, today.day, kwargs.pop('seed', 0)))
+            kwargs['rng_key'] = rng_key
+        rule = ru.make_rule(rule_name, **kwargs)
+
+        # if a constraint is specified, make a constrained rule instead.
+        if constraint is not None:
+            return ru.ConstrainedRule(rule, constraint)
+        else:
+            return rule
+
+    @classmethod
+    def from_config(cls, config: str):
+        """populate policy object from a yaml config file"""
+        # first we load the text content of config into a string for
+        # later use
+        if op.isfile(config):
+            with open(config, "r") as f:
+                config_text = f.read()
+        else:
+            config_text = config
+        # then we pre-load the config to populate some common fields in
+        # the policy
+        loader = cfg.get_loader()
+        loader.add_constructor("!rule", cls.rule_constructor)
+        config = yaml.load(config_text, Loader=loader)
+        # remove fields that need special handling later on
+        config.pop('blocks')
+        # now we can construct the policy
+        return cls(config_text=config_text, **config)
+
+    def init_seqs(self, t0: dt.datetime, t1: dt.datetime) -> core.BlocksTree:
+        # prepare some specialized loaders: !source [source_name], !toast [toast schedule name]
+        def source_constructor(t0, t1, loader, node):
+            return src.source_gen_seq(loader.construct_scalar(node), t0, t1)
+        def toast_constructor(loader, node):
+            return utils.parse_sequence_from_toast(loader.construct_scalar(node))
+        loader = cfg.get_loader()
+        loader.add_constructor('!source', lambda loader, node: source_constructor(t0, t1, loader, node))
+        loader.add_constructor('!toast', lambda loader, node: toast_constructor(loader, node))
+        # load blocks for processing
+        blocks = yaml.load(self.config_text, Loader=loader)["blocks"]
+        return core.seq_trim(blocks, t0, t1)
+
+    def transform(self, blocks: core.BlocksTree) -> core.BlocksTree:
+        # apply each rule
+        for rule in self.rules: 
+            blocks = rule(blocks)
+
+        return blocks
+
+    def merge(self, blocks: core.BlocksTree) -> core.Blocks:
+        """merge blocks into a single sequence by the order specified
+        in self.merge_order, assuming an ascending priority order as moving
+        down the merge_order list."""
+        seq = None
+        for query in self.merge_order:
+            match, _ = core.seq_partition_with_query(query, blocks)
+            if seq is None: 
+                seq = match
+                continue
+            else:
+                # match takes precedence
+                seq = core.seq_merge(seq, match, flatten=True)
+
+        # apply transformation if needed
+        for rule in self.post_rules:
+            seq = rule(seq)
+
+        return core.seq_sort(seq)
+
+    def block2cmd(self, block: core.Block):
+        if isinstance(block, inst.ScanBlock):
+            return cmd.CompositeCommand([
+                    f"# {block.name}",
+                    cmd.Goto(block.az, block.alt),
+                    cmd.BiasDets(),
+                    cmd.Wait(block.t0),
+                    cmd.BiasStep(),
+                    cmd.Scan(block.name, block.t1, block.throw),
+                    cmd.BiasStep(),
+                    "",
+            ])
+
+    def seq2cmd(self, seq: core.Blocks):
+        """map a scan to a command"""
+        commands = core.seq_flatten(core.seq_map(self.block2cmd, seq))
+        commands = [cmd.Preamble()] + commands
+        return cmd.CompositeCommand(commands)

--- a/src/schedlib/rules.py
+++ b/src/schedlib/rules.py
@@ -136,8 +136,9 @@ class MakeSourcePlan(MappableRule):
         # we should stop scanning when the source is at this alt
         alt_stop = alt + sign*alt_height
         # total passage time
-        obs_length = utils.interp_extra(alt_stop, alt, t) - t
-        assert np.all(obs_length >= 0), "passage time must be positive, something is wrong"
+        obs_length = utils.interp_extra(alt_stop, alt, t, fill_value=np.nan) - t
+        ok = np.logical_not(np.isnan(obs_length))
+        assert np.all(obs_length[ok] >= 0), "passage time must be positive, something is wrong"
 
         # this is where our boresight pointing should be to observe the passage.
         # this places our wafer set at the center of the source path, so the source
@@ -170,7 +171,7 @@ class MakeSourcePlan(MappableRule):
         az_bore   = az_center - az_offset
 
         # get validity ranges
-        ok = utils.within_bound(alt_stop, [alt.min(), alt.max()])
+        ok *= utils.within_bound(alt_stop, [alt.min(), alt.max()])
         if self.bounds_alt is not None:
             ok *= utils.within_bound(alt_bore, self.bounds_alt)
         if self.bounds_az_throw is not None:

--- a/src/schedlib/rules.py
+++ b/src/schedlib/rules.py
@@ -25,6 +25,17 @@ class MappableRule(GreenRule, ABC):
         return True
 
 @dataclass(frozen=True)
+class ConstrainedRule(GreenRule):
+    """ConstrainedRule applies a rule to a subset of blocks. Here
+    constraint is a fnmatch pattern that matches to the `key` of a
+    block."""
+    rule: core.Rule
+    constraint: str
+    def apply(self, blocks: core.BlocksTree) -> core.BlocksTree:
+        matched, unmatched = core.seq_partition_wth_query(self.constraint, blocks)
+        return core.seq_combine(self.rule(matched), unmatched)
+
+@dataclass(frozen=True)
 class AltRange(MappableRule):
     """Restrict the altitude range of source blocks. 
 
@@ -259,4 +270,5 @@ def get_rule(name: str) -> core.Rule:
     return RULES[name]
 
 def make_rule(name: str, **kwargs) -> core.Rule:
+    assert name in RULES, f"unknown rule {name}"
     return get_rule(name)(**kwargs)

--- a/src/schedlib/rules.py
+++ b/src/schedlib/rules.py
@@ -1,7 +1,6 @@
 from typing import Tuple, Dict, List, Optional
 import numpy as np
 from chex import dataclass
-from functools import partial
 from abc import ABC, abstractmethod
 import datetime as dt
 

--- a/src/schedlib/rules.py
+++ b/src/schedlib/rules.py
@@ -1,8 +1,8 @@
 from typing import Tuple, Dict, List, Optional
 import numpy as np
-from chex import dataclass
 from abc import ABC, abstractmethod
 import datetime as dt
+from dataclasses import dataclass
 
 from . import core, source as src, instrument as inst, utils
 

--- a/src/schedlib/rules.py
+++ b/src/schedlib/rules.py
@@ -255,7 +255,7 @@ class MakeSourceScan(MappableRule):
             allowance = duration - preferred_len
             offset = utils.uniform(self.rng_key, 0, allowance)
             t0 = block.t0 + dt.timedelta(seconds=offset)
-            scan = block.get_scan_starting_at(t0)
+            scan = block.get_scan_at_t0(t0)
         elif self.fixed_alt is not None:
             scan = block.get_scan_at_alt(self.fixed_alt)
         else:

--- a/src/schedlib/rules.py
+++ b/src/schedlib/rules.py
@@ -90,9 +90,9 @@ class RephaseFirst(GreenRule):
         # identify the first block as the first in the sorted list
         src = core.seq_sort(core.seq_flatten(blocks))[0]
         # randomize the phase of it but not too much
-        allowance = min(self.max_fraction * src.duration,
-                        max(src.duration - self.min_block_size, 0))
-        tgt = src.replace(t0=src.t0 + utils.uniform(self.rng_key, 0, allowance))
+        allowance = min(self.max_fraction * src.duration.total_seconds(),
+                        max(src.duration.total_seconds() - self.min_block_size, 0))
+        tgt = src.replace(t0=src.t0 + dt.timedelta(seconds=utils.uniform(self.rng_key, 0, allowance)))
         return core.seq_replace_block(blocks, src, tgt)
 
 @dataclass(frozen=True)

--- a/src/schedlib/source.py
+++ b/src/schedlib/source.py
@@ -28,10 +28,21 @@ class Location(NamedTuple):
         obs.date = ephem.date(date)
         return obs
 
+def _debabyl(deg, arcmin, arcsec):
+    return deg + arcmin/60 + arcsec/3600
+
+SITES = {
+    'act':   Location(lat=-22.9585, lon=-67.7876, elev=5188),
+    'lat':   Location(lat=-_debabyl(22,57,39.47), lon=-_debabyl(67,47,15.68), elev=5188),
+    'satp1': Location(lat=-_debabyl(22,57,36.38), lon=-_debabyl(67,47,18.11), elev=5188),
+    'satp2': Location(lat=-_debabyl(22,57,36.35), lon=-_debabyl(67,47,17.28), elev=5188),
+    'satp3': Location(lat=-_debabyl(22,57,35.97), lon=-_debabyl(67,47,16.53), elev=5188),
+}
 DEFAULT_SITE = Location(lat=-22.958, lon=-67.786, elev=5200)
 
-def get_site() -> Location:
-    return DEFAULT_SITE
+def get_site(site='lat') -> Location:
+    """use lat as default following so3g convention"""
+    return SITES[site]
 
 # source needs to be callable to avoid side effects
 SOURCES = {

--- a/src/schedlib/source.py
+++ b/src/schedlib/source.py
@@ -65,7 +65,9 @@ def _source_get_az_alt(source: str, times: List[dt.datetime]):
         source.compute(observer)
         az.append(np.rad2deg(source.az))
         alt.append(np.rad2deg(source.alt))
-    return np.array(az), np.array(alt)
+    az = np.unwrap(np.array(az), period=360)
+    alt = np.array(alt)
+    return az, alt
 
 def _source_az_alt_interpolators(source: str, t0: dt.datetime, t1: dt.datetime, time_step: dt.timedelta):
     times = [t0 + i * time_step for i in range(int((t1 - t0) / time_step))]

--- a/src/schedlib/source.py
+++ b/src/schedlib/source.py
@@ -219,3 +219,7 @@ class ObservingWindow(SourceBlock):
             alt=float(alt),
             throw=float(az_throw),
         )
+    def get_scan_at_alt(self, alt: float) -> inst.ScanBlock:
+        """get a possible scan at a given altitude"""
+        t0 = utils.interp_bounded(alt, self.alt_bore, self.t_start)
+        return self.get_scan_starting_at(t0)

--- a/src/schedlib/source.py
+++ b/src/schedlib/source.py
@@ -201,7 +201,7 @@ class ObservingWindow(SourceBlock):
     az_bore: core.Arr[float]
     alt_bore: core.Arr[float]
     az_throw: core.Arr[float]
-    def get_scan_starting_at(self, t0: dt.datetime) -> inst.ScanBlock:
+    def get_scan_at_t0(self, t0: dt.datetime) -> inst.ScanBlock:
         """get a possible scan starting at t0"""
         t_req = int(t0.timestamp())
         # if we start at t0, we can observe for at most obs_length
@@ -222,4 +222,4 @@ class ObservingWindow(SourceBlock):
     def get_scan_at_alt(self, alt: float) -> inst.ScanBlock:
         """get a possible scan at a given altitude"""
         t0 = utils.interp_bounded(alt, self.alt_bore, self.t_start)
-        return self.get_scan_starting_at(t0)
+        return self.get_scan_at_t0(t0)

--- a/src/schedlib/source.py
+++ b/src/schedlib/source.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 
 from __future__ import annotations
-from chex import dataclass
+from dataclasses import dataclass
 import ephem
 from ephem import to_timezone
 import datetime as dt
@@ -12,7 +12,6 @@ import numpy as np
 from . import core, utils, instrument as inst
 
 UTC = dt.timezone.utc
-
 
 class Location(NamedTuple):
     """Location given in degrees and meters"""

--- a/src/schedlib/utils.py
+++ b/src/schedlib/utils.py
@@ -7,6 +7,7 @@ from contextlib import contextmanager
 from typing import Any, List
 from scipy import interpolate
 from collections.abc import Iterable
+from jax.tree_util import SequenceKey, DictKey
 
 from . import core, utils as u, instrument as inst
 
@@ -159,3 +160,19 @@ def pprint(seq: core.BlocksTree):
     """pretty print"""
     from equinox import tree_pprint
     tree_pprint(seq)
+
+# ====================
+# path related
+# ====================
+
+def path2key(path):
+    """convert a path (used in tree_util.tree_map_with_path) to a dot-separated key"""
+    keys = []
+    for p in path:
+        if isinstance(p, SequenceKey):
+            keys.append(p.idx)
+        elif isinstance(p, DictKey):
+            keys.append(p.key)
+        else:
+            raise ValueError(f"unknown path type {type(p)}")
+    return ".".join([str(k) for k in keys])

--- a/src/schedlib/utils.py
+++ b/src/schedlib/utils.py
@@ -99,9 +99,9 @@ def parse_sequence_from_toast(ifile: str) -> core.Blocks:
     return blocks
 
 # convenience wrapper for interpolation: numpy-like scipy interpolate
-def interp_extra(x_new, x, y):
+def interp_extra(x_new, x, y, fill_value='extrapolate'):
     """interpolate with extrapolation"""
-    return interpolate.interp1d(x, y, fill_value='extrapolate', bounds_error=False, kind='cubic', assume_sorted=False)(x_new)
+    return interpolate.interp1d(x, y, fill_value=fill_value, bounds_error=False, kind='cubic', assume_sorted=False)(x_new)
 
 def interp_bounded(x_new, x, y):
     """interpolate with bounded extrapolation"""

--- a/src/schedlib/utils.py
+++ b/src/schedlib/utils.py
@@ -9,7 +9,7 @@ from scipy import interpolate
 from collections.abc import Iterable
 from jax.tree_util import SequenceKey, DictKey
 
-from . import core, utils as u, instrument as inst
+from . import core, instrument as inst
 
 
 minute = 60 # second
@@ -89,8 +89,8 @@ def parse_sequence_from_toast(ifile: str) -> core.Blocks:
     for _, row in df.iterrows():
         block = inst.ScanBlock(
             name=row['patch'].strip(),
-            t0=u.str2datetime(row['start_utc']),
-            t1=u.str2datetime(row['stop_utc']),
+            t0=str2datetime(row['start_utc']),
+            t1=str2datetime(row['stop_utc']),
             alt=row['el'],
             az=row['az_min'],
             throw=np.abs(row['az_max'] - row['az_min']),

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,15 @@
+import yaml
+import pytest
+import datetime as dt
+from schedlib import config as cfg
+
+@pytest.fixture
+def config_str():
+    return """
+    date_ref: !datetime 2014-01-01 00:00:00
+    """
+
+def test_loader(config_str):
+    loader = cfg.get_loader()
+    config = yaml.load(config_str, Loader=loader)
+    assert config['date_ref'] == dt.datetime(2014, 1, 1, 0, 0, 0, tzinfo=dt.timezone.utc)

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -620,3 +620,42 @@ def test_seq_partition_with_path():
     assert unmatched['C'] == core.Block(t0=dt.datetime(2023, 1, 5, 0, 0), t1=dt.datetime(2023, 1, 6, 0, 0))
 
     assert core.seq_combine(matched, unmatched) == blocks
+
+def test_seq_partition_with_query():
+    blocks = {
+        "A": core.Block(t0=dt.datetime(2023, 1, 1), t1=dt.datetime(2023, 1, 2)),
+        "B": [core.Block(t0=dt.datetime(2023, 1, 3), t1=dt.datetime(2023, 1, 4)),
+              core.Block(t0=dt.datetime(2023, 1, 4), t1=dt.datetime(2023, 1, 5))],
+        "C": core.Block(t0=dt.datetime(2023, 1, 5), t1=dt.datetime(2023, 1, 6)),
+    }
+
+    matched, unmatched = core.seq_partition_with_query("B.*", blocks)
+
+    # Now validate individual blocks
+    assert matched['A'] == None
+    assert matched['B'][0] == core.Block(t0=dt.datetime(2023, 1, 3, 0, 0), t1=dt.datetime(2023, 1, 4, 0, 0))
+    assert matched['B'][1] == core.Block(t0=dt.datetime(2023, 1, 4), t1=dt.datetime(2023, 1, 5))
+    assert matched['C'] == None
+
+    assert unmatched['A'] == core.Block(t0=dt.datetime(2023, 1, 1, 0, 0), t1=dt.datetime(2023, 1, 2, 0, 0))
+    assert unmatched['B'][0] == None
+    assert unmatched['B'][1] == None
+    assert unmatched['C'] == core.Block(t0=dt.datetime(2023, 1, 5, 0, 0), t1=dt.datetime(2023, 1, 6, 0, 0))
+
+    assert core.seq_combine(matched, unmatched) == blocks
+
+    # case 2:
+    matched, unmatched = core.seq_partition_with_query("B.1", blocks)
+    # Now validate individual blocks
+    # assert matched['A'] == core.Block(t0=dt.datetime(2023, 1, 1, 0, 0), t1=dt.datetime(2023, 1, 2, 0, 0))
+    assert matched['A'] == None
+    assert matched['B'][0] == None
+    assert matched['B'][1] == core.Block(t0=dt.datetime(2023, 1, 4), t1=dt.datetime(2023, 1, 5))
+    assert matched['C'] == None
+
+    assert unmatched['A'] == core.Block(t0=dt.datetime(2023, 1, 1, 0, 0), t1=dt.datetime(2023, 1, 2, 0, 0))
+    assert unmatched['B'][0] == core.Block(t0=dt.datetime(2023, 1, 3, 0, 0), t1=dt.datetime(2023, 1, 4, 0, 0))
+    assert unmatched['B'][1] == None
+    assert unmatched['C'] == core.Block(t0=dt.datetime(2023, 1, 5, 0, 0), t1=dt.datetime(2023, 1, 6, 0, 0))
+
+    assert core.seq_combine(matched, unmatched) == blocks

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -559,3 +559,64 @@ def test_seq_merge():
         core.Block(t0=dt.datetime(2023, 1, 5), t1=dt.datetime(2023, 1, 6))
     ]
     assert core.seq_merge(seq5, seq6, flatten=True) == expected_result3
+
+def test_seq_partition():
+    blocks = [
+        core.Block(t0=dt.datetime(2023, 1, 1), t1=dt.datetime(2023, 1, 2)),
+        [core.Block(t0=dt.datetime(2023, 1, 3), t1=dt.datetime(2023, 1, 4))],
+        core.Block(t0=dt.datetime(2023, 1, 5), t1=dt.datetime(2023, 1, 6)),
+    ]
+
+    t0 = dt.datetime(2023, 1, 2)
+    t1 = dt.datetime(2023, 1, 5)
+
+    def in_range(block):
+        """Return True if the block is within the range [t0, t1], False otherwise."""
+        return (block.t0 > t0 and block.t1 < t1)
+
+    matched, unmatched = core.seq_partition(in_range, blocks)
+
+    # Now validate individual blocks
+    assert matched[0] == None
+    assert matched[1][0] == core.Block(t0=dt.datetime(2023, 1, 3, 0, 0), t1=dt.datetime(2023, 1, 4, 0, 0))
+    assert matched[2] == None
+
+    assert unmatched[0] == core.Block(t0=dt.datetime(2023, 1, 1, 0, 0), t1=dt.datetime(2023, 1, 2, 0, 0))
+    assert unmatched[1][0] == None
+    assert unmatched[2] == core.Block(t0=dt.datetime(2023, 1, 5, 0, 0), t1=dt.datetime(2023, 1, 6, 0, 0))
+
+    assert core.seq_combine(matched, unmatched) == blocks
+
+def test_seq_partition_with_path():
+    from schedlib import utils
+
+    blocks = {
+        "A": core.Block(t0=dt.datetime(2023, 1, 1), t1=dt.datetime(2023, 1, 2)),
+        "B": [core.Block(t0=dt.datetime(2023, 1, 3), t1=dt.datetime(2023, 1, 4)),
+              core.Block(t0=dt.datetime(2023, 1, 4), t1=dt.datetime(2023, 1, 5))],
+        "C": core.Block(t0=dt.datetime(2023, 1, 5), t1=dt.datetime(2023, 1, 6)),
+    }
+
+    t0 = dt.datetime(2023, 1, 2)
+    t1 = dt.datetime(2023, 1, 5)
+
+    def in_range(path, block):
+        """Return True if the block is within the range [t0, t1], False otherwise."""
+        if utils.path2key(path) == 'B.1':
+            return False
+        return (block.t0 > t0 and block.t1 < t1)
+
+    matched, unmatched = core.seq_partition_with_path(in_range, blocks)
+
+    # Now validate individual blocks
+    assert matched['A'] == None
+    assert matched['B'][0] == core.Block(t0=dt.datetime(2023, 1, 3, 0, 0), t1=dt.datetime(2023, 1, 4, 0, 0))
+    assert matched['B'][1] == None
+    assert matched['C'] == None
+
+    assert unmatched['A'] == core.Block(t0=dt.datetime(2023, 1, 1, 0, 0), t1=dt.datetime(2023, 1, 2, 0, 0))
+    assert unmatched['B'][0] == None
+    assert unmatched['B'][1] == core.Block(t0=dt.datetime(2023, 1, 4, 0, 0), t1=dt.datetime(2023, 1, 5, 0, 0))
+    assert unmatched['C'] == core.Block(t0=dt.datetime(2023, 1, 5, 0, 0), t1=dt.datetime(2023, 1, 6, 0, 0))
+
+    assert core.seq_combine(matched, unmatched) == blocks

--- a/tests/test_instrument.py
+++ b/tests/test_instrument.py
@@ -1,4 +1,6 @@
-from schedlib.instrument import get_spec
+import numpy as np
+import os.path as op
+import schedlib.instrument as inst
 
 def test_get_spec():
     specs = {
@@ -13,25 +15,31 @@ def test_get_spec():
             },
         }
     }
-    spec = get_spec(specs, ["platform1"])
+    spec = inst.get_spec(specs, ["platform1"])
     assert spec == {
         'bounds_x': [-2.0, 1.0],
         'bounds_y': [-2.0, 1.0],
     }
-    spec = get_spec(specs, ["wafer1"])
+    spec = inst.get_spec(specs, ["wafer1"])
     assert spec == {
         'bounds_x': [-1.0, 1.0],
         'bounds_y': [-1.0, 1.0],
     }
-    spec = get_spec(specs, ["platform1.wafer2"])
+    spec = inst.get_spec(specs, ["platform1.wafer2"])
     assert spec == {
         'bounds_x': [-2.0, 1.0],
         'bounds_y': [-2.0, 1.0],
     }
-    spec = get_spec(specs, ["wafer"])
+    spec = inst.get_spec(specs, ["wafer"])
     assert spec == {
         'bounds_x': [-2.0, 1.0],
         'bounds_y': [-2.0, 1.0],
     }
-    spec = get_spec(specs, ["wafer3"])
+    spec = inst.get_spec(specs, ["wafer3"])
     assert spec == {}
+
+def test_parse_sequence_from_toast():
+    ifile = op.join(op.abspath(op.dirname(__file__)), "data/schedule_test.txt")
+    seq = inst.parse_sequence_from_toast(ifile)
+    print(seq)
+    assert len(seq) == 17

--- a/tests/test_instrument.py
+++ b/tests/test_instrument.py
@@ -43,3 +43,41 @@ def test_parse_sequence_from_toast():
     seq = inst.parse_sequence_from_toast(ifile)
     print(seq)
     assert len(seq) == 17
+
+def test_array_info():
+    geometries = {
+        'w11': {
+            'center': [0, 0],
+            'radius': 1.0,
+        },
+        'w22': {
+            'center': [1, 1],
+            'radius': 1.0,
+        }
+    }
+    array_info1 = inst.make_circular_cover(*geometries['w11']['center'], geometries['w11']['radius'])
+    array_info2 = inst.make_circular_cover(*geometries['w22']['center'], geometries['w22']['radius'])
+    assert array_info1['cover'].shape == (2, 50)
+    query = "w11,w22"
+    array_info = inst.array_info_from_query(geometries, query)
+    assert array_info['cover'].shape == (2, 100)
+    assert np.allclose(array_info['center'], np.mean([array_info1['center'], array_info2['center']], axis=0))
+    assert np.allclose(array_info['cover'], np.concatenate([array_info1['cover'], array_info2['cover']], axis=1))
+
+    query = "w1*"
+    array_info = inst.array_info_from_query(geometries, query)
+    assert array_info['cover'].shape == (2, 50)
+    assert np.allclose(array_info['center'], array_info1['center'])
+    assert np.allclose(array_info['cover'], array_info1['cover'])
+
+    query = "*2"
+    array_info = inst.array_info_from_query(geometries, query)
+    assert array_info['cover'].shape == (2, 50)
+    assert np.allclose(array_info['center'], array_info2['center'])
+    assert np.allclose(array_info['cover'], array_info2['cover'])
+
+    query = "*2,*1"
+    array_info = inst.array_info_from_query(geometries, query)
+    assert array_info['cover'].shape == (2, 100)
+    assert np.allclose(array_info['center'], np.mean([array_info1['center'], array_info2['center']], axis=0))
+    assert np.allclose(array_info['cover'], np.concatenate([array_info1['cover'], array_info2['cover']], axis=1))

--- a/tests/test_policies.py
+++ b/tests/test_policies.py
@@ -46,3 +46,43 @@ def test_basic_policy():
         dt.datetime(2023, 1, 1, 0, 0, 0, tzinfo=dt.timezone.utc),
         dt.datetime(2023, 1, 10, 1, 0, 0, tzinfo=dt.timezone.utc))
     policy.apply(seqs)
+
+def test_flex_policy():
+    config = """
+    blocks:
+      master: !toast data/schedule_test.txt
+      calibration:
+        uranus: !source uranus
+        moon: !source moon
+    rules:
+      - !rule 
+         name: sun-avoidance
+         min_angle_az: 6
+         min_angle_alt: 6
+         time_step: 30
+         n_buffer: 10
+      - !rule 
+         name: day-mod
+         day: 0
+         day_mod: 1
+         day_ref: !datetime "2014-01-01 00:00:00"
+      - !rule
+         name: rephase-first
+         max_fraction: 0.1
+         min_block_size: 600    
+    post_rules:
+      - !rule
+        name: min-duration
+        min_duration: 600
+    merge_order:
+      - master
+      - uranus
+      - moon
+    """
+    policy = policies.FlexPolicy.from_config(config)
+    seqs = policy.init_seqs(
+        dt.datetime(2023, 1, 1, 0, 0, 0, tzinfo=dt.timezone.utc),
+        dt.datetime(2023, 1, 10, 1, 0, 0, tzinfo=dt.timezone.utc))
+    policy.apply(seqs)
+    seqs = policy.transform(seqs)
+    seqs = policy.merge(seqs)

--- a/tests/test_policies.py
+++ b/tests/test_policies.py
@@ -52,32 +52,36 @@ def test_flex_policy():
     blocks:
       master: !toast data/schedule_test.txt
       calibration:
-        uranus: !source uranus
+        saturn: !source saturn
         moon: !source moon
     rules:
-      - !rule 
-         name: sun-avoidance
-         min_angle_az: 6
-         min_angle_alt: 6
-         time_step: 30
-         n_buffer: 10
-      - !rule 
-         name: day-mod
-         day: 0
-         day_mod: 1
-         day_ref: !datetime "2014-01-01 00:00:00"
-      - !rule
-         name: rephase-first
-         max_fraction: 0.1
-         min_block_size: 600    
+      - name: sun-avoidance
+        min_angle_az: 6
+        min_angle_alt: 6
+        time_step: 30
+        n_buffer: 10
+      - name: day-mod
+        day: 0
+        day_mod: 1
+        day_ref: !datetime "2014-01-01 00:00:00"
+      - name: make-drift-scan
+        constraint: calibration
+        array_query: full
+        el_bore: 50
+        drift: true
     post_rules:
-      - !rule
-        name: min-duration
+      - name: min-duration
         min_duration: 600
     merge_order:
-      - master
-      - uranus
       - moon
+      - saturn
+      - master
+    geometries:
+      full:
+        center:
+          - 0
+          - 0
+        radius: 7
     """
     policy = policies.FlexPolicy.from_config(config)
     seqs = policy.init_seqs(

--- a/tests/test_source.py
+++ b/tests/test_source.py
@@ -32,7 +32,7 @@ def test_source_get_az_alt():
     source = 'sun'
     times = [dt.datetime(2023, 1, 1, tzinfo=dt.timezone.utc)]
     expected_az = [240.15972382]
-    expected_alt = [-9.02030811]
+    expected_alt = [-9.01748468]
     az, alt = src._source_get_az_alt(source, times)
     assert np.allclose(az, expected_az)
     assert np.allclose(alt, expected_alt)
@@ -49,7 +49,7 @@ def test_source_get_az_alt():
         dt.datetime(2023, 1, 2, 0, 0, 0, tzinfo=dt.timezone.utc),
         dt.datetime(2023, 1, 3, 0, 0, 0, tzinfo=dt.timezone.utc)
     ]
-    expected_az = [302.09675348, 301.27609259, 300.48474687]
+    expected_az = [302.1017805 , 301.28101033, 300.48955533]
     expected_alt = [52.57749508, 51.85943046, 51.13723016]
     az, alt = src._source_get_az_alt(source, times)
     assert np.allclose(az, expected_az)
@@ -62,26 +62,26 @@ def test_source_get_blocks():
     blocks = src.source_get_blocks(source, t0, t1)
     assert blocks == [
         src.SourceBlock(
-            t0=dt.datetime(2022, 12, 31, 9, 48, 9, 902594, tzinfo=dt.timezone.utc),
-            t1=dt.datetime(2022, 12, 31, 16, 34, 11, 308132, tzinfo=dt.timezone.utc),
+            t0=dt.datetime(2022, 12, 31, 9, 48, 9, 937409, tzinfo=dt.timezone.utc),
+            t1=dt.datetime(2022, 12, 31, 16, 34, 11, 713598, tzinfo=dt.timezone.utc),
             name='sun',
             mode='rising'
         ),
         src.SourceBlock(
-            t0=dt.datetime(2022, 12, 31, 16, 34, 11, 308132, tzinfo=dt.timezone.utc),
-            t1=dt.datetime(2022, 12, 31, 23, 20, 7, 342350, tzinfo=dt.timezone.utc),
+            t0=dt.datetime(2022, 12, 31, 16, 34, 11, 713598, tzinfo=dt.timezone.utc),
+            t1=dt.datetime(2022, 12, 31, 23, 20, 8, 117595, tzinfo=dt.timezone.utc),
             name='sun',
             mode='setting'
         ),
         src.SourceBlock(
-            t0=dt.datetime(2023, 1, 1, 9, 48, 48, 46183, tzinfo=dt.timezone.utc),
-            t1=dt.datetime(2023, 1, 1, 16, 34, 39, 671616, tzinfo=dt.timezone.utc),
+            t0=dt.datetime(2023, 1, 1, 9, 48, 48, 82430, tzinfo=dt.timezone.utc),
+            t1=dt.datetime(2023, 1, 1, 16, 34, 40, 77082, tzinfo=dt.timezone.utc),
             name='sun',
             mode='rising'
         ),
         src.SourceBlock(
-            t0=dt.datetime(2023, 1, 1, 16, 34, 39, 671616, tzinfo=dt.timezone.utc),
-            t1=dt.datetime(2023, 1, 1, 23, 20, 25, 379071, tzinfo=dt.timezone.utc),
+            t0=dt.datetime(2023, 1, 1, 16, 34, 40, 77082, tzinfo=dt.timezone.utc),
+            t1=dt.datetime(2023, 1, 1, 23, 20, 26, 152794, tzinfo=dt.timezone.utc),
             name='sun',
             mode='setting'
         )
@@ -95,7 +95,7 @@ def test_precomputed_source():
     assert len(source.blocks) == 4
 
     t = int(dt.datetime(2023, 1, 1, 5, 0, 0, tzinfo=dt.timezone.utc).timestamp())
-    assert np.allclose(source.interp_az(t), [295.34634092])
+    assert np.allclose(source.interp_az(t), [-64.65207448])
     assert np.allclose(source.interp_alt(t), [15.48141435])
 
     assert 'uranus' in src.PRECOMPUTED_SOURCES
@@ -122,13 +122,13 @@ def test_source_gen_seq():
     assert blocks == [
         src.SourceBlock(
             t0=dt.datetime(2023, 1, 1, 0, 0, tzinfo=dt.timezone.utc),
-            t1=dt.datetime(2023, 1, 1, 0, 40, 38, 505632, tzinfo=dt.timezone.utc),
+            t1=dt.datetime(2023, 1, 1, 0, 40, 38, 909838, tzinfo=dt.timezone.utc),
             name='uranus',
             mode='rising'
         ),
         src.SourceBlock(
-            t0=dt.datetime(2023, 1, 1, 0, 40, 38, 505632, tzinfo=dt.timezone.utc),
-            t1=dt.datetime(2023, 1, 1, 6, 14, 17, 34180, tzinfo=dt.timezone.utc),
+            t0=dt.datetime(2023, 1, 1, 0, 40, 38, 909838, tzinfo=dt.timezone.utc),
+            t1=dt.datetime(2023, 1, 1, 6, 14, 17, 199762, tzinfo=dt.timezone.utc),
             name='uranus',
             mode='setting'
         )
@@ -143,5 +143,5 @@ def test_source_block_get_az_alt():
     )
     times, az, alt = src.source_block_get_az_alt(srcblk)
     assert len(times) == 67
-    assert np.allclose(az[:5], [83.97807382, 395.73085271, 349.995829, 362.00775543, 358.54644389])
-    assert np.allclose(alt[:5], [51.01782363, 51.01763853, 51.01706878, 51.01611489, 51.01477258])
+    assert np.allclose(az[:5], [0.00580815, -0.18562059, -0.37705974, -0.56848984, -0.75989556])
+    assert np.allclose(alt[:5], [51.01486071, 51.01468336, 51.01411836, 51.01316534, 51.01183098])

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -53,12 +53,6 @@ def test_mask2ranges_digest():
     for i_left, i_right in mask2ranges(mask):
         assert np.all(mask[i_left:i_right])
 
-def test_parse_sequence_from_toast():
-    ifile = op.join(op.abspath(op.dirname(__file__)), "data/schedule_test.txt")
-    seq = parse_sequence_from_toast(ifile)
-    print(seq)
-    assert len(seq) == 17
-
 def test_ranges_pad():
     mask = np.array([False, False, True, True, False, False, False, True, True, True, False, False])
     ranges = mask2ranges(mask)


### PR DESCRIPTION
- This PR adds a new policy called `flex` which allows making planet-only schedules and allow a custom merging order should conflicts occur. 
- Also added a new rule that generate fixed elevation planet scan which supports az drift. 
