### PR TITLE
add support for boresight rotation in source scan

### DIFF
--- a/src/schedlib/instrument.py
+++ b/src/schedlib/instrument.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 from jax import tree_util as tu
 import pandas as pd
-from typing import List, TypeVar, Union, Dict
+from typing import List, TypeVar, Union, Dict, Optional
 import numpy as np
 from functools import reduce
 from dataclasses import dataclass
@@ -15,6 +15,7 @@ class ScanBlock(core.NamedBlock):
     alt: float       # deg
     throw: float     # deg
     az_drift: float = 0. # deg / s
+    boresight_angle: Optional[float] = None # deg
     subtype: str = ""
     tag: str = ""
 

--- a/src/schedlib/policies/sat.py
+++ b/src/schedlib/policies/sat.py
@@ -137,17 +137,27 @@ class SATPolicy:
             # if not, let's alternate between targets
             if core.seq_has_overlap(cal_blocks[source]):
                 # one target per source block (e.g. per transit)
-                rules = [
-                    (
-                        tagname,
-                        ru.MakeCESourceScan(
-                            array_info=inst.array_info_from_query(self.geometries, array_query),
-                            el_bore=el_bore,
-                            drift=True
-                        ),
+                rules = []
+                for cal_target in self.cal_targets:
+                    if len(cal_target) == 4:
+                        source, array_query, el_bore, tagname = cal_target
+                        boresight_rot = None
+                    elif len(cal_target) == 5:
+                        source_, array_query, el_bore, boresight_rot, tagname = cal_target
+                    else:
+                        raise ValueError("cal_target has an unrecognized format")
+                    if source_ != source: continue
+                    rules.append(
+                        (
+                            tagname,
+                            ru.MakeCESourceScan(
+                                array_info=inst.array_info_from_query(self.geometries, array_query),
+                                el_bore=el_bore,
+                                drift=True,
+                                boresight_rot=boresight_rot,
+                            ),
+                        )
                     )
-                    for source_, array_query, el_bore, tagname in self.cal_targets if source_ == source 
-                ]
 
                 new_blocks = []
                 rule_i = 0

--- a/src/schedlib/policies/sat.py
+++ b/src/schedlib/policies/sat.py
@@ -106,7 +106,15 @@ class SATPolicy:
         
         # plan source scans
         cal_blocks = {}
-        for source, array_query, el_bore, tagname in self.cal_targets:
+        for cal_target in self.cal_targets:
+            if len(cal_target) == 4:
+                source, array_query, el_bore, tagname = cal_target
+                boresight_rot = None
+            elif len(cal_target) == 5:
+                source, array_query, el_bore, boresight_rot, tagname = cal_target
+            else:
+                raise ValueError("cal_target has an unrecognized format")
+
             assert source in blocks['calibration'], f"source {source} not found in sequence"
 
             array_info = inst.array_info_from_query(self.geometries, array_query)
@@ -114,6 +122,7 @@ class SATPolicy:
                 array_info=array_info, 
                 el_bore=el_bore, 
                 drift=True,
+                boresight_rot=boresight_rot,
             )
 
             if source not in cal_blocks: cal_blocks[source] = []

--- a/src/schedlib/policies/sat.py
+++ b/src/schedlib/policies/sat.py
@@ -65,6 +65,7 @@ class SATPolicy:
     scan_tag: Optional[str] = None
     az_speed: float = 1. # deg / s
     az_accel: float = 2. # deg / s^2
+    apply_boresight_rot: bool = False
     checkpoints: dict[str, core.BlocksTree] = field(default_factory=dict)
     
     def save_checkpoint(self, name, blocks):
@@ -257,7 +258,7 @@ class SATPolicy:
                         f"run.wait_until('{block.t0.isoformat()}')"
                     ]
 
-                    if block.boresight_angle is not None and block.boresight_rot != cur_boresight_angle:
+                    if self.apply_boresight_rot and block.boresight_angle is not None and block.boresight_rot != cur_boresight_angle:
                         commands += [
                             f"run.acu.set_boresight({block.boresight_angle})",
                         ]
@@ -286,7 +287,7 @@ class SATPolicy:
                         f"run.wait_until('{t_start.isoformat()}')",
                     ]
 
-                    if block.boresight_angle is not None and block.boresight_rot != cur_boresight_angle:
+                    if self.apply_boresight_rot and block.boresight_angle is not None and block.boresight_rot != cur_boresight_angle:
                         commands += [
                             f"run.acu.set_boresight({block.boresight_angle})",
                         ]

--- a/src/schedlib/rules.py
+++ b/src/schedlib/rules.py
@@ -369,6 +369,7 @@ class MakeCESourceScan(MappableRule):
     el_bore: float  # deg
     drift: bool = True
     allow_partial: bool = False
+    boresight_rot: Optional[float] = None
 
     def apply_block(self, block: core.Block) -> core.Block: 
         if isinstance(block, src.SourceBlock):
@@ -378,7 +379,8 @@ class MakeCESourceScan(MappableRule):
             v_az = 0 if not self.drift else None
             return src.make_source_ces(block, array_info=self.array_info, 
                                        allow_partial=self.allow_partial,
-                                       el_bore=self.el_bore, v_az=v_az)
+                                       el_bore=self.el_bore, v_az=v_az,
+                                       boresight_rot=self.boresight_rot)
         else:
             return block
 

--- a/src/schedlib/source.py
+++ b/src/schedlib/source.py
@@ -264,7 +264,7 @@ def _find_az_bore(el_bore, az_src, el_src, q_point, atol=0.01):
     return az_bore
 
 def make_source_ces(block, array_info, el_bore=50, 
-        allow_partial=False, v_az=None
+        allow_partial=False, v_az=None, boresight_rot=None
     ):
     """make a ces scan of a source
 
@@ -278,8 +278,10 @@ def make_source_ces(block, array_info, el_bore=50,
         elevation of the boresight in degrees
     allow_partial: bool
         if True, allow partial coverage of the array
-    v_az: float
+    v_az: Optional[float]
         az drift speed in az in deg/s, if None, will try to find optimal drift speed
+    boresight_rot: Optional[float]
+        rotation of the boresight in deg
 
     Returns
     -------
@@ -290,6 +292,12 @@ def make_source_ces(block, array_info, el_bore=50,
     assert 'center' in array_info and 'cover' in array_info, 'array_info must contain center and cover'
     q_center = quat.rotation_xieta(*array_info['center'])
     q_cover = quat.rotation_xieta(*array_info['cover'])
+
+    # apply boresight rotation if specified
+    if boresight_rot is not None:
+        q_bore_rot = quat.euler(2, np.deg2rad(boresight_rot))
+        q_center = q_bore_rot * q_center
+        q_cover = q_bore_rot * q_cover
 
     t, az_src, el_src = block.get_az_alt()  # degs
     t_src_interp = interpolate.interp1d(

--- a/src/schedlib/source.py
+++ b/src/schedlib/source.py
@@ -372,6 +372,7 @@ def make_source_ces(block, array_info, el_bore=50,
             t0=u.ct2dt(float(t0)),
             t1=u.ct2dt(float(t1)),
             az_drift=v_az,
+            boresight_angle=boresight_rot,
             tag=f"{block.name},{block.mode}"
         )
     except ValueError:


### PR DESCRIPTION
for `SATPolicy`, in the `cal_targets`, in addition to the original format: `(source_name, array_query, el_bore, tagname)`, one can also pass in a boresight rotation angle in degrees: `(source_name, array_query, el_bore, boresight_rot, tagname)`. It remains backwards compatible. 