### PR TITLE
don't skip calibration operations we're editing these by hand

### DIFF
--- a/src/schedlib/policies/sat.py
+++ b/src/schedlib/policies/sat.py
@@ -474,7 +474,7 @@ class SATPolicy:
                 print(f"Planning block {block.name}")
                 print(f"Setup time is {setup_time/60} minutes")
             # det setup
-            if t_cur + dt.timedelta(seconds=setup_time) > block.t1:
+            if block.subtype == 'cmb' and t_cur + dt.timedelta(seconds=setup_time) > block.t1:
                 commands += [
                     "\"\"\"",
                     f"Note: {block} skipped due to insufficient time",


### PR DESCRIPTION
Because of https://github.com/simonsobs/scheduler/issues/43 we're currently editing the output schedules by hand to remove CMB scans that happen before a beam calibration scan and we consider the beam calibration scans more important than cmb scans. So don't skip a cal scan for something we'll remove by hand afterwards. 