### PR TITLE
Set up for ISO

### DIFF
--- a/src/schedlib/commands.py
+++ b/src/schedlib/commands.py
@@ -358,6 +358,12 @@ def wait_until(state, t1: dt.datetime):
         f"run.wait_until('{t1.isoformat()}')"
     ]
 
+@operation(name='start_time')
+def start_time(state):
+    return state, [
+        f"run.wait_until('{state.curr_time.isoformat()}')"
+    ]
+
 @operation(name="move_to", duration=0)
 def move_to(state, az, el, force=False):
     if not force and (state.az_now == az and state.el_now == el):

--- a/src/schedlib/instrument.py
+++ b/src/schedlib/instrument.py
@@ -27,6 +27,8 @@ class ScanBlock(core.NamedBlock):
         Azimuth drift rate in degrees per second (default is 0).
     az_speed : float, optional
         Azimuth speed in degrees per second (default is 1).
+    az_accel : float, optional
+        Azimuth acceleration in degrees per second squared (default is 2).
     boresight_angle : float, optional
         Boresight angle in degrees (default is None).
     subtype : str, optional
@@ -39,6 +41,7 @@ class ScanBlock(core.NamedBlock):
     throw: float     # deg
     az_drift: float = 0. # deg / s
     az_speed: float = 1. # deg / s
+    az_accel: float = 2. # deg / s**2
     boresight_angle: Optional[float] = None # deg
     subtype: str = ""
     tag: str = ""

--- a/src/schedlib/policies/sat.py
+++ b/src/schedlib/policies/sat.py
@@ -37,7 +37,7 @@ class State(cmd.State):
     is_det_setup : bool
         Whether the detectors have been set up or not.
     """
-    boresight_rot_now: int = 0
+    boresight_rot_now: float = 0
     hwp_spinning: bool = False
     last_ufm_relock: Optional[dt.datetime] = None
     last_bias_step: Optional[dt.datetime] = None

--- a/src/schedlib/policies/sat.py
+++ b/src/schedlib/policies/sat.py
@@ -6,7 +6,7 @@ import yaml
 import os.path as op
 from dataclasses import dataclass, field
 import datetime as dt
-from typing import List, Union, Optional, Dict, Any
+from typing import List, Union, Optional, Dict, Any, Tuple
 import jax.tree_util as tu
 from functools import reduce
 
@@ -207,7 +207,21 @@ def det_setup(state, block, apply_boresight_rot=True, iv_cadence=None):
 
 @cmd.operation(name='sat.cmb_scan', return_duration=True)
 def cmb_scan(state, block):
-    commands = [
+    if (
+        block.az_speed != state.az_speed_now or 
+        block.az_accel != state.az_accel_now
+    ):
+        commands = [
+            f"run.acu.set_scan_params({block.az_speed}, {block.az_accel})"
+        ]
+        state = state.replace(
+            az_speed_now=block.az_speed, 
+            az_accel_now=block.az_accel
+        )
+    else:
+        commands = []
+
+    commands.extend([
         f"scan_stop = {repr(block.t1)}",
         f"if datetime.datetime.now(tz=UTC) < scan_stop - datetime.timedelta(minutes=10):",
         "    run.seq.scan(",
@@ -216,7 +230,7 @@ def cmb_scan(state, block):
         f"        width={round(block.throw,3)}, az_drift=0,",
         f"        subtype='cmb', tag='{block.tag}',",
         "    )",
-    ]
+    ])
     return state, (block.t1 - state.curr_time).total_seconds(), commands
 
 @cmd.operation(name='sat.source_scan', return_duration=True)
@@ -224,8 +238,22 @@ def source_scan(state, block):
     block = block.trim_left_to(state.curr_time)
     if block is None:
         return state, 0, ["# too late, don't scan"]
+    if (
+        block.az_speed != state.az_speed_now or 
+        block.az_accel != state.az_accel_now
+    ):
+        commands = [
+            f"run.acu.set_scan_params({block.az_speed}, {block.az_accel})"
+        ]
+        state = state.replace(
+            az_speed_now=block.az_speed, 
+            az_accel_now=block.az_accel
+        )
+    else:
+        commands = []
+    
     state = state.replace(az_now=block.az, el_now=block.alt)
-    return state, block.duration.total_seconds(), [
+    commands.extend([
         "now = datetime.datetime.now(tz=UTC)",
         f"scan_start = {repr(block.t0)}",
         f"scan_stop = {repr(block.t1)}",
@@ -251,14 +279,17 @@ def source_scan(state, block):
         f"        subtype='{block.subtype}',",
         f"        tag='{block.tag}',",
         "    )",
-    ]
+    ])
+    return state, block.duration.total_seconds(), commands
 
 @cmd.operation(name='sat.setup_boresight', return_duration=True)
 def setup_boresight(state, block, apply_boresight_rot=True):
     commands = []
     duration = 0
 
-    if apply_boresight_rot and state.boresight_rot_now != block.boresight_angle:
+    if apply_boresight_rot and (
+            state.boresight_rot_now is None or state.boresight_rot_now != block.boresight_angle
+        ):
         commands += [f"run.acu.set_boresight({block.boresight_angle})"]
         state = state.replace(boresight_rot_now=block.boresight_angle)
         duration += 1*u.minute
@@ -316,6 +347,8 @@ class SATPolicy:
     cal_targets: List[CalTarget] = field(default_factory=list)
     cal_policy: str = 'round-robin'
     scan_tag: Optional[str] = None
+    iso_scan_speeds: Optional =None
+    boresight_override: Optional[float] = None
     az_speed: float = 1. # deg / s
     az_accel: float = 2. # deg / s^2
     allow_az_maneuver: bool = True
@@ -366,7 +399,14 @@ class SATPolicy:
             if loader_cfg['type'] == 'source':
                 return src.source_gen_seq(loader_cfg['name'], t0, t1)
             elif loader_cfg['type'] == 'toast':
-                return inst.parse_sequence_from_toast(loader_cfg['file'])
+                blocks = inst.parse_sequence_from_toast(loader_cfg['file'])
+                if self.boresight_override is not None:
+                    blocks = core.seq_map(
+                        lambda b: b.replace(
+                            boresight_angle=self.boresight_override
+                        ), blocks
+                    )
+                return blocks
             else:
                 raise ValueError(f"unknown sequence type: {loader_cfg['type']}")
 
@@ -385,7 +425,7 @@ class SATPolicy:
             lambda b: isinstance(b, inst.ScanBlock),
             lambda b: b.replace(az_speed=self.az_speed),
             blocks
-        )
+        )   
 
         # trim to given time range
         blocks = core.seq_trim(blocks, t0, t1)
@@ -483,7 +523,11 @@ class SATPolicy:
 
             # add tags to the scans
             cal_blocks.append(core.seq_map(
-                lambda block: block.replace(tag=f"{block.tag},{target.tag}"),
+                lambda block: block.replace(
+                                az_speed = self.az_speed,
+                                az_accel = self.az_accel,
+                                tag=f"{block.tag},{target.tag}"
+                            ),
                 source_scans
             ))
 
@@ -543,6 +587,19 @@ class SATPolicy:
             )
 
         blocks = core.seq_sort(blocks['baseline']['cmb'] + blocks['calibration'], flatten=True)
+
+        # alternate scan speeds for ISO testing
+        # run after flattening to presume order is set
+        if self.iso_scan_speeds is not None:
+            self.c = 0
+            def iso_set(block):
+                if block.subtype != 'cmb':
+                    return block
+                v,a = self.iso_scan_speeds[ self.c % len(self.iso_scan_speeds)]
+                self.c += 1
+                return block.replace(az_speed=v, az_accel=a)
+            blocks = core.seq_map(iso_set, blocks)
+            del self.c
 
         return blocks
 

--- a/src/schedlib/policies/satp1.py
+++ b/src/schedlib/policies/satp1.py
@@ -59,8 +59,8 @@ def make_geometry():
 
 def make_cal_target(
     source: str, 
-    boresight: int, 
-    elevation: int, 
+    boresight: float, 
+    elevation: float, 
     focus: str, 
     allow_partial=False,
     drift=True,
@@ -89,18 +89,18 @@ def make_cal_target(
         },
     }
 
-    boresight = int(boresight)
-    elevation = int(elevation)
+    boresight = float(boresight)
+    elevation = float(elevation)
     focus = focus.lower()
 
     focus_str = None
-    if boresight not in array_focus:
+    if int(boresight) not in array_focus:
         logger.warning(
             f"boresight not in {array_focus.keys()}, assuming {focus} is a wafer string"
         )
         focus_str = focus ##
     else:
-        focus_str = array_focus[boresight].get(focus, focus)
+        focus_str = array_focus[int(boresight)].get(focus, focus)
 
     assert source in src.SOURCES, f"source should be one of {src.SOURCES.keys()}"
 

--- a/src/schedlib/policies/stages/build_op.py
+++ b/src/schedlib/policies/stages/build_op.py
@@ -144,7 +144,7 @@ class BuildOp:
         logger.info(u.pformat(ir_ops))
 
         logger.info(f"================ done ================")
-
+        
         return ir_ops
 
     def lower(self, seq, t0, t1, state, operations):


### PR DESCRIPTION
I'm not totally sure I'm done with this. But a large start and what SATp1 will run this week. Things this PR does

1. Adds az_accel to blocks b/c we're doing nonsense with turnarounds
2. cmb and cal operations now check for az speed/accel state changes
3. Add an option to implement an ISO-like alternating scan speed for every cmb scan
4. Adds option to override the toast schedule boresight since it's annoyingly wrong right now
5. If `state.boresight_rot_now` is None then boresight rotation is applied
6. Add a start_time operation that just prints a wait_until the state current time. 