### PR TITLE
One fix and one work-around related to Sun Avoidance

### DIFF
--- a/src/schedlib/instrument.py
+++ b/src/schedlib/instrument.py
@@ -99,6 +99,8 @@ class ScanBlock(core.NamedBlock):
 
         """
         t0, t1 = u.dt2ct(self.t0), u.dt2ct(self.t1)
+        # Additional buffer distance for turn-arounds (like ACU Agent)
+        turn = self.az_speed**2 / self.az_accel
 
         # allow passing in a list of ctimes
         if ctimes is not None:
@@ -108,8 +110,8 @@ class ScanBlock(core.NamedBlock):
 
         # find left and right az limits, accounting for drift
         drift = self.az_drift * (t-t0)
-        left = self.az + drift
-        right = self.az + self.throw + drift
+        left = self.az + drift - turn
+        right = self.az + self.throw + drift + turn
 
         # calculate the phase of the scan, assuming it
         # moves at a constant speed from az to az+throw

--- a/src/schedlib/instrument.py
+++ b/src/schedlib/instrument.py
@@ -295,8 +295,9 @@ def parse_sequence_from_toast(ifile):
         List of ScanBlock objects parsed from the input file.
 
     """
-    columns = ["start_utc", "stop_utc", "rotation", "patch", "az_min", "az_max", "el", "pass", "sub"]
-
+    #columns = ["start_utc", "stop_utc", "rotation", "patch", "az_min", "az_max", "el", "pass", "sub"]
+    columns = ["start_utc", "stop_utc", "rotation", "az_min", "az_max", "el", "pass", "sub", "patch"]
+    
     # count the number of lines to skip
     with open(ifile) as f:
         for i, l in enumerate(f):

--- a/src/schedlib/policies/__init__.py
+++ b/src/schedlib/policies/__init__.py
@@ -1,4 +1,5 @@
 from .flex import FlexPolicy
 from .sat import SATPolicy
 from .satp1 import SATP1Policy
+from .satp2 import SATP2Policy
 from .satp3 import SATP3Policy

--- a/src/schedlib/policies/sat.py
+++ b/src/schedlib/policies/sat.py
@@ -62,6 +62,7 @@ class CalTarget:
     boresight_rot: float = 0
     allow_partial: bool = False
     drift: bool = True
+    az_branch: float = None
 
 # ----------------------------------------------------
 #                  Register operations
@@ -558,6 +559,7 @@ class SATPolicy:
                 drift=True,
                 boresight_rot=target.boresight_rot,
                 allow_partial=target.allow_partial,
+                az_branch=target.az_branch,
             )
             source_scans = rule(blocks['calibration'][target.source])
             source_scans = core.seq_flatten(source_scans)

--- a/src/schedlib/policies/satp1.py
+++ b/src/schedlib/policies/satp1.py
@@ -66,6 +66,7 @@ def make_cal_target(
     focus: str, 
     allow_partial=False,
     drift=True,
+    az_branch=None,
 ) -> CalTarget:
     array_focus = {
         0 : {
@@ -106,6 +107,9 @@ def make_cal_target(
 
     assert source in src.SOURCES, f"source should be one of {src.SOURCES.keys()}"
 
+    if az_branch is None:
+        az_branch = 180.
+
     return CalTarget(
         source=source, 
         array_query=focus_str, 
@@ -113,7 +117,8 @@ def make_cal_target(
         boresight_rot=boresight, 
         tag=focus_str,
         allow_partial=allow_partial,
-        drift=drift
+        drift=drift,
+        az_branch=az_branch,
     )
 
 def make_blocks(master_file):

--- a/src/schedlib/policies/satp2.py
+++ b/src/schedlib/policies/satp2.py
@@ -1,0 +1,299 @@
+import numpy as np
+from dataclasses import dataclass
+import datetime as dt
+
+from typing import Optional
+
+from .. import source as src, utils as u
+from .sat import SATPolicy, State, CalTarget
+from ..commands import SchedMode
+
+logger = u.init_logger(__name__)
+
+
+# ----------------------------------------------------
+#         setup satp2 specific configs
+# ----------------------------------------------------
+
+def make_geometry():
+    ws0_shift = np.degrees([0, 0])
+    ws1_shift = np.degrees([0, 0])
+    ws2_shift = np.degrees([0, 0])
+    ws3_shift = np.degrees([0, 0])
+    ws4_shift = np.degrees([0, 0])
+    ws5_shift = np.degrees([0, 0])
+    ws6_shift = np.degrees([0, 0])
+
+    ## default SAT optics offests
+    d_xi = 10.9624
+    d_eta_side = 6.46363
+    d_eta_mid = 12.634
+
+    return {
+        'ws3': {
+            'center': [-d_xi+ws3_shift[0], d_eta_side+ws3_shift[1]],
+            'radius': 6,
+        },
+        'ws2': {
+            'center': [-d_xi+ws2_shift[0], -d_eta_side+ws2_shift[1]],
+            'radius': 6,
+        },
+        'ws4': {
+            'center': [0+ws4_shift[0], d_eta_mid+ws4_shift[1]],
+            'radius': 6,
+        },
+        'ws0': {
+            'center': [0+ws0_shift[0], 0+ws0_shift[1]],
+            'radius': 6,
+        },
+        'ws1': {
+            'center': [0+ws1_shift[0], -d_eta_mid+ws1_shift[1]],
+            'radius': 6,
+        },
+        'ws5': {
+            'center': [d_xi+ws5_shift[0], d_eta_side+ws5_shift[1]],
+            'radius': 6,
+        },
+        'ws6': {
+            'center': [d_xi+ws6_shift[0], -d_eta_side+ws6_shift[1]],
+            'radius': 6,
+        },
+    }
+
+def make_cal_target(
+    source: str, 
+    boresight: float, 
+    elevation: float, 
+    focus: str, 
+    allow_partial=False,
+    drift=True,
+    az_branch=None,
+) -> CalTarget:
+    array_focus = {
+        0 : {
+            'left' : 'ws3,ws2',
+            'middle' : 'ws0,ws1,ws4',
+            'right' : 'ws5,ws6',
+            'bottom': 'ws1,ws2,ws6',
+            'all' : 'ws0,ws1,ws2,ws3,ws4,ws5,ws6',
+        },
+        45 : {
+            'left' : 'ws3,ws4',
+            'middle' : 'ws2,ws0,ws5',
+            'right' : 'ws1,ws6',
+            'bottom': 'ws1,ws2,ws3',
+            'all' : 'ws0,ws1,ws2,ws3,ws4,ws5,ws6',
+        },
+        -45 : {
+            'left' : 'ws1,ws2',
+            'middle' : 'ws6,ws0,ws3',
+            'right' : 'ws4,ws5',
+            'bottom': 'ws1,ws6,ws5',
+            'all' : 'ws0,ws1,ws2,ws3,ws4,ws5,ws6',
+        },
+    }
+
+    boresight = float(boresight)
+    elevation = float(elevation)
+    focus = focus.lower()
+
+    focus_str = None
+    if int(boresight) not in array_focus:
+        logger.warning(
+            f"boresight not in {array_focus.keys()}, assuming {focus} is a wafer string"
+        )
+        focus_str = focus ##
+    else:
+        focus_str = array_focus[int(boresight)].get(focus, focus)
+
+    assert source in src.SOURCES, f"source should be one of {src.SOURCES.keys()}"
+
+    if az_branch is None:
+        az_branch = 180.
+
+    return CalTarget(
+        source=source, 
+        array_query=focus_str, 
+        el_bore=elevation, 
+        boresight_rot=boresight, 
+        tag=focus_str,
+        allow_partial=allow_partial,
+        drift=drift,
+        az_branch=az_branch,
+    )
+
+def make_blocks(master_file):
+    return {
+        'baseline': {
+            'cmb': {
+                'type': 'toast',
+                'file': master_file
+            }
+        },
+        'calibration': {
+            'saturn': {
+                'type' : 'source',
+                'name' : 'saturn',
+            },
+            'jupiter': {
+                'type' : 'source',
+                'name' : 'jupiter',
+            },
+            'moon': {
+                'type' : 'source',
+                'name' : 'moon',
+            },
+            'uranus': {
+                'type' : 'source',
+                'name' : 'uranus',
+            },
+            'neptune': {
+                'type' : 'source',
+                'name' : 'neptune',
+            },
+            'mercury': {
+                'type' : 'source',
+                'name' : 'mercury',
+            },
+            'venus': {
+                'type' : 'source',
+                'name' : 'venus',
+            },
+            'mars': {
+                'type' : 'source',
+                'name' : 'mars',
+            }
+        },
+    }
+
+def make_operations(
+    az_speed, az_accel, disable_hwp=False, 
+    apply_boresight_rot=True, hwp_cfg=None, hwp_dir=True,
+    iv_cadence=4*u.hour, stow_at_end=False, run_relock=False
+):
+    if hwp_cfg is None:
+        hwp_cfg = { 'iboot2': 'power-iboot-hwp-2', 'pid': 'hwp-pid', 'pmx': 'hwp-pmx', 'hwp-pmx': 'pmx', 'gripper': 'hwp-gripper', 'forward':hwp_dir }
+    pre_session_ops = [
+        { 'name': 'sat.preamble'        , 'sched_mode': SchedMode.PreSession},
+        { 'name': 'start_time'          ,'sched_mode': SchedMode.PreSession},
+        { 'name': 'set_scan_params' , 'sched_mode': SchedMode.PreSession, 'az_speed': az_speed, 'az_accel': az_accel, },
+    ]
+    if run_relock:
+        pre_session_ops += [
+            { 'name': 'sat.ufm_relock'      , 'sched_mode': SchedMode.PreSession, }
+        ]
+    cal_ops = [
+        { 'name': 'sat.setup_boresight' , 'sched_mode': SchedMode.PreCal, 'apply_boresight_rot': apply_boresight_rot, },
+        { 'name': 'sat.det_setup'       , 'sched_mode': SchedMode.PreCal, 'apply_boresight_rot': apply_boresight_rot, 'iv_cadence':iv_cadence },
+        { 'name': 'sat.hwp_spin_up'     , 'sched_mode': SchedMode.PreCal, 'disable_hwp': disable_hwp, 'forward':hwp_dir},
+        { 'name': 'sat.source_scan'     , 'sched_mode': SchedMode.InCal, },
+        { 'name': 'sat.bias_step'       , 'sched_mode': SchedMode.PostCal, 'indent': 4},
+    ]
+    cmb_ops = [
+        { 'name': 'sat.setup_boresight' , 'sched_mode': SchedMode.PreObs, 'apply_boresight_rot': apply_boresight_rot, },
+        { 'name': 'sat.det_setup'       , 'sched_mode': SchedMode.PreObs, 'apply_boresight_rot': apply_boresight_rot, 'iv_cadence':iv_cadence},
+        { 'name': 'sat.hwp_spin_up'     , 'sched_mode': SchedMode.PreObs, 'disable_hwp': disable_hwp, 'forward':hwp_dir},
+        { 'name': 'sat.bias_step'       , 'sched_mode': SchedMode.PreObs, },
+        { 'name': 'sat.cmb_scan'        , 'sched_mode': SchedMode.InObs, },
+        { 'name': 'sat.bias_step'       , 'sched_mode': SchedMode.PostObs, 'indent': 4, 'divider': ['']},
+    ]
+    if stow_at_end:
+        post_session_ops = [
+            { 'name': 'sat.hwp_spin_down'   , 'sched_mode': SchedMode.PostSession, 'disable_hwp': disable_hwp, },
+            { 'name': 'sat.wrap_up'         , 'sched_mode': SchedMode.PostSession, 'az_stow': 180, 'el_stow': 50},
+        ]
+    else:
+        post_session_ops = []
+    return pre_session_ops + cal_ops + cmb_ops + post_session_ops
+
+def make_config(
+    master_file,
+    az_speed,
+    az_accel,
+    cal_targets,
+    boresight_override=None,
+    **op_cfg
+):
+    blocks = make_blocks(master_file)
+    geometries = make_geometry()
+    operations = make_operations(
+        az_speed, az_accel,
+        **op_cfg
+    )
+
+    sun_policy = { 'min_angle': 41, 'min_sun_time': 1980 }
+
+    config = {
+        'blocks': blocks,
+        'geometries': geometries,
+        'rules': {
+            'min-duration': {
+                'min_duration': 600
+            },
+            'sun-avoidance': sun_policy,
+        },
+        'operations': operations,
+        'cal_targets': cal_targets,
+        'scan_tag': None,
+        'boresight_override': boresight_override,
+        'az_speed' : az_speed,
+        'az_accel' : az_accel,
+        'stages': {
+            'build_op': {
+                'plan_moves': {
+                    'sun_policy': sun_policy,
+                    'az_step': 0.5,
+                    'az_limits': [-45, 405],
+                }
+            }
+        }
+    }
+    return config
+
+
+# ----------------------------------------------------
+#
+#         Policy customizations, if any
+#
+# ----------------------------------------------------
+# here we add some convenience wrappers
+
+@dataclass
+class SATP2Policy(SATPolicy):
+    state_file: Optional[str] = None
+
+    @classmethod
+    def from_defaults(cls, master_file, az_speed=0.8, az_accel=1.5, 
+        cal_targets=[], boresight_override=None, 
+        state_file=None, **op_cfg
+    ):
+        x = cls(**make_config(
+            master_file, az_speed, az_accel, 
+            cal_targets, boresight_override, **op_cfg
+        ))
+        x.state_file=state_file
+        return x
+
+    def add_cal_target(self, *args, **kwargs):
+        self.cal_targets.append(make_cal_target(*args, **kwargs))
+
+    def init_state(self, t0: dt.datetime) -> State:
+        """customize typical initial state for satp1, if needed"""
+        if self.state_file is not None:
+            logger.info(f"using state from {self.state_file}")
+            state = State.load(self.state_file)
+            if state.curr_time < t0:
+                logger.info(
+                    f"Loaded state is at {state.curr_time}. Updating time to"
+                    f" {t0}"
+                )
+                state = state.replace(curr_time = t0)
+            return state
+
+        return State(
+            curr_time=t0,
+            az_now=180,
+            el_now=48,
+            boresight_rot_now=None,
+            hwp_spinning=False,
+        )

--- a/src/schedlib/policies/satp3.py
+++ b/src/schedlib/policies/satp3.py
@@ -64,6 +64,7 @@ def make_cal_target(
     focus: str,
     allow_partial=False,
     drift=True,
+    az_branch=None,
 ) -> CalTarget:
     array_focus = {
         'left' : 'ws3,ws2',
@@ -86,6 +87,9 @@ def make_cal_target(
 
     assert source in src.SOURCES, f"source should be one of {src.SOURCES.keys()}"
 
+    if az_branch is None:
+        az_branch = 180.
+
     return CalTarget(
         source=source,
         array_query=focus_str,
@@ -93,7 +97,8 @@ def make_cal_target(
         boresight_rot=boresight,
         tag=focus_str,
         allow_partial=allow_partial,
-        drift=drift
+        drift=drift,
+        az_branch=az_branch,
     )
 
 def make_blocks(master_file):

--- a/src/schedlib/policies/stages/build_op.py
+++ b/src/schedlib/policies/stages/build_op.py
@@ -625,161 +625,78 @@ class PlanMoves:
     def apply(self, seq):
         """take a list of IR from BuildOp as input to solve for optimal sun-safe moves"""
 
-        # compute sun safe az ranges for each block
-        def f(block):
-            sun_tracker = get_sun_tracker(u.dt2ct(block.t0), policy=self.sun_policy)  # TODO: allow policy updates
-            # we want to find what az ranges at this alt are safe to cover 
-            # the entire block duration + min_sun_time
-            az_full = np.arange(self.az_limits[0], self.az_limits[1]+self.az_step, self.az_step)
-            alt = az_full*0 + block.alt 
-            sun_times, _ = sun_tracker.check_trajectory(t=u.dt2ct(block.t0), az=az_full, el=alt, raw=True)
-            # we have already checked all scans for sun safety, we just need the beginning
-            # of these blocks to be sun safe for moving purpose
-            if block.subtype == IRMode.InBlock:
-                m = sun_times > self.sun_policy['min_sun_time']
-            else:
-                m = sun_times > (block.duration.total_seconds() + self.sun_policy['min_sun_time'])
-            ranges = u.mask2ranges(m)
-            ranges = u.ranges_pad(ranges, 1, len(az_full))  # 1 sample tolerance
-            az_ranges = [(az_full[r[0]], az_full[r[1]-1]) for r in ranges]
-            return az_ranges
-
         seq = core.seq_sort(seq, flatten=True)
 
-        # fill up gaps first
-        gapfill = core.NamedBlock(name='_gap', t0=seq[0].t0, t1=seq[-1].t1)
-        seq = core.seq_sort(core.seq_merge([gapfill], seq, flatten=True))
+        def get_traj_ok_time(az0, az1, alt0, alt1, t0):
+            #Returns the timestamp until which the move from
+            #(az0, alt0) to (az1, alt1) is sunsafe.
+            sun_tracker = get_sun_tracker(u.dt2ct(t0), policy=self.sun_policy)
+            az = np.linspace(az0, az1, 101)
+            el = np.linspace(alt0, alt1, 101)
+            if alt0 != alt1 or az0 != az1:
+                az1 = (az[:,None] + el[None,:]*0).ravel()
+                el1 = (az[:,None]*0 + el[None,:]).ravel()
+                az, el = az1, el1
+            sun_safety = sun_tracker.check_trajectory(t=u.dt2ct(t0), az=az, el=el)
+            return u.ct2dt(u.dt2ct(t0) + sun_safety['sun_time'])
 
-        # replace _gap with proper IR and give it proper pointing
-        seq_ = []
-        for i in range(len(seq)):
-            block = seq[i]
-            if block.name == '_gap' and i == 0:
-                raise ValueError("first block cannot be a gap")
-            # use previous block's az for gap by default
-            if block.name == '_gap':
-                block = IR(name='gap', subtype=IRMode.Gap, t0=block.t0, t1=block.t1, 
-                           az=seq[i-1].az, alt=seq[i-1].alt)
-            seq_ += [block]
+        def get_safe_gaps(block0, block1):
+            """Returns a list with 0, 1, or 2 Gap blocks.  The Gap blocks will be
+            at sunsafe positions for their duration, and be safely reachable
+            in the sequence block0 -> gaps -> block1.
 
-        seq_body = seq_[1:-1]  # skip pre/post session blocks for now
-        sun_intervals = core.seq_map(f, seq_body) 
+            The az and alt specified for a gap will be sun safe at the
+            block0.t1 and block1.t0, with a preference for the az and
+            alt of block1.
 
-        def get_az_options(ir: IR, sints: List[Tuple[float, float]]) -> List[float]:
-            if ir.subtype == IRMode.InBlock:
-                return [ir.block.az]
-            return [ir.az]
-
-        def xxx_get_az_options(ir: IR, sints: List[Tuple[float, float]]) -> List[float]:
-            """As our goal is to find az movement plan that minimally deviates 
-            from original plan, this resembles a linear programming problem, so
-            the optimal solution will lie in one of the vertices of the feasible 
-            region.
             """
-            if ir.subtype == IRMode.InBlock:
-                block = ir.block
-                az_options = find_unwrap(block.az, self.az_limits)
-                az_options = [az for az in az_options if az+block.throw < self.az_limits[1]]
-            else:
-                az_options = []
-                if az_ranges_contain(sints, ir.az):
-                    az_options += find_unwrap(ir.az, self.az_limits)
-                az_options += [y for x in sints for y in x]
-            return az_options
+            if (block0.t1 >= block1.t0):
+                return []
+            # Check the move
+            t1 = get_traj_ok_time(block0.az, block1.az, block0.alt, block1.alt,
+                                  block1.t1)
+            if t1 >= block1.t0:
+                return [IR(name='gap', subtype=IRMode.Gap, t0=block0.t1, t1=block1.t0,
+                           az=block1.az, alt=block1.alt)]
+            # Try to do it in two steps!
+            # ... exertcise for reader.
+            raise
 
-        # pairs: List[((b_prev, b_next), (sints_prev, sints_next))]
-        pairs = list(zip(zip(seq_body[:-1], seq_body[1:]), zip(sun_intervals[:-1], sun_intervals[1:])))
-
-        def recur(pairs: List[Any]) -> List[Tuple[float, List[float]]]:
-            """
-            Reduce shortest path problem to a series of subproblems:
-            min(sum(az_diff)) = min(az_diff_prev + min(sum(az_diff_subsequent))).
-            As no branching is needed, we can use a simple recursion
-            """
-            car, cdr = pairs[0], pairs[1:]
-            (b_prev, b_next), (sints_prev, sints_next) = car
-
-            # we want to stay in az ranges valid for both blocks
-            sints_both = az_ranges_intersect(sints_prev, sints_next, 
-                                             az_limits=self.az_limits, az_step=self.az_step)
-            if len(sints_both) == 0:
-                logger.error(f"no sun safe az ranges found between: {b_prev.t0} -> {b_next.t1}")
-                logger.error(f"prev: {b_prev}")
-                logger.error(f"next: {b_next}")
-                raise ValueError(f"no sun safe az ranges found between: {b_prev.t0} -> {b_next.t1}, "
-                                 f"consider making a schedule that ends by {b_prev.t0}.")
-
-            # get az options for b_prev
-            # our convention is that move happens inside next block,
-            # not the current block. The difference is subtle: when 
-            # adding in next block, we need to park our telescope 
-            # at a safe az for both blocks (i.e. sint_both: safe 
-            # intervals for both)
-            az_options = get_az_options(b_prev, sints_both)
-
-            # get az options for b_next
-            if len(cdr) == 0:  
-                # when we are at the end of our sequence
-                az_options_next = get_az_options(b_next, sints_next)
-                moves_rest = []
-                for az_next in az_options_next:
-                    # r = az_distance(az_next, b_next.az)
-                    r = 0  # minimize total az travel
-                    moves_rest += [(r, [az_next])]
-            else:
-                moves_rest = recur(cdr)
-
-            # find possible moves 
-            moves = []
-            for az_prev in az_options:
-                allowed = []
-                for m in moves_rest:
-                    r, [az_next, *az_rest] = m
-                    track = (az_prev, az_next) if az_prev < az_next else (az_next, az_prev)
-                    if az_ranges_cover(sints_next, track):
-                        # how much are we deviating from original plan?
-                        # r += az_distance(az_prev, b_prev.az)
-                        r += az_distance(az_prev, az_next)
-                        allowed += [(r, [az_prev, az_next, *az_rest])]
-                if len(allowed) > 0:
-                    moves += [min(allowed)]
-            if len(moves) == 0:
-                raise ValueError(f"no moves found between {b_prev} and {b_next}, very unusual!")
-            return sorted(moves)  # sort by overall az difference
+        seq_ = [seq[0]]
+        for i in range(1, len(seq)):
+            gaps = get_safe_gaps(seq[i-1], seq[i])
+            seq_.extend(gaps)
+            seq_.append(seq[i])
         
-        # moves: List[(dist, [az_seq...]]
-        moves = recur(pairs)
-        assert len(moves) > 0, "unexpected exception, an exception should have been raised earlier"
-        best_move = moves[0]
-        logger.info(f"found a best move that deviates from original plan by {best_move[0]:.3f} degrees overall in az")
-
-        # apply moves to the sequence
-        # -> change az of each block in the sequence
-        # -> inject MoveTo blocks in between blocks
-        az_seq = best_move[-1]
-        updated = []
-        for i, b in enumerate(seq_body):
-            b = b.replace(az=az_seq[i])
-            # no need to worry about gap
-            if b.name == 'gap': 
-                updated += [b]
+        # Replace gaps with Wait, Move, Wait.
+        seq_, seq = [], seq_
+        last_az, last_alt = None, None
+        # Combine, but skipping first and last blocks, which are init/shutdown.
+        for b in seq:
+            print(b.name)
+            if b.name in ['pre_session', 'post_session']:
+                # Pre/post-ambles, leave it alone.
+                seq_ += [b]
+            elif b.name == 'gap':
+                # For a gap, always seek to the stated gap position.
+                # But not until the gap is supposed to start.  Since
+                # gaps may be used to manage Sun Avoidance, it's
+                # important to be in that place for that time period.
+                seq_ += [
+                    WaitUntil(t1=b.t0, az=b.az, alt=b.alt),
+                    MoveTo(az=b.az, alt=b.alt),
+                    WaitUntil(t1=b.t1, az=b.az, alt=b.alt)]
+                last_az, last_alt = b.az, b.alt
             else:
-                if i == 0:
-                    updated += [WaitUntil(t1=b.t0, az=seq[0].az, alt=seq[0].alt), MoveTo(az=az_seq[0], alt=b.alt), b]
-                else:
-                    if ~np.isclose(az_seq[i], az_seq[i-1]):
-                        updated += [WaitUntil(t1=b.t0, az=az_seq[i-1], alt=seq_body[i-1].alt), MoveTo(az=az_seq[i], alt=b.alt), b]
-                    else:
-                        updated += [b]
+                if (last_az is None
+                    or np.round(b.az - last_az, 3) != 0
+                    or np.round(b.alt - last_alt, 3) != 0):
+                    seq_ += [MoveTo(az=b.az, alt=b.alt)]
+                    last_az, last_alt = b.az, b.alt
+                seq_ += [b]
 
-        # for every scan block, we add a move_to after it to make az deterministic
-        # otherwise if we start late, we don't know the phase of az at the end of
-        # the block so sun safety calculation can be wrong if the scan is wide enough.
-        updated = core.seq_flatten(
-            core.seq_map(lambda b: [b, MoveTo(az=b.az, alt=b.alt)] if b.subtype == IRMode.PostBlock else [b], updated)
-        )
-        updated = [seq[0]] + updated + [seq[-1]]
-        return updated 
+        return seq_
+
 
 @dataclass(frozen=True)
 class SimplifyMoves:

--- a/src/schedlib/policies/stages/build_op.py
+++ b/src/schedlib/policies/stages/build_op.py
@@ -666,6 +666,11 @@ class PlanMoves:
         sun_intervals = core.seq_map(f, seq_body) 
 
         def get_az_options(ir: IR, sints: List[Tuple[float, float]]) -> List[float]:
+            if ir.subtype == IRMode.InBlock:
+                return [ir.block.az]
+            return [ir.az]
+
+        def xxx_get_az_options(ir: IR, sints: List[Tuple[float, float]]) -> List[float]:
             """As our goal is to find az movement plan that minimally deviates 
             from original plan, this resembles a linear programming problem, so
             the optimal solution will lie in one of the vertices of the feasible 

--- a/src/schedlib/rules.py
+++ b/src/schedlib/rules.py
@@ -367,6 +367,7 @@ class MakeCESourceScan(core.MappableRule):
     drift: bool = True
     allow_partial: bool = False
     boresight_rot: Optional[float] = None
+    az_branch: Optional[float] = None
 
     def apply_block(self, block: core.Block) -> core.Block: 
         if isinstance(block, src.SourceBlock):
@@ -377,7 +378,8 @@ class MakeCESourceScan(core.MappableRule):
             return src.make_source_ces(block, array_info=self.array_info, 
                                        allow_partial=self.allow_partial,
                                        el_bore=self.el_bore, v_az=v_az,
-                                       boresight_rot=self.boresight_rot)
+                                       boresight_rot=self.boresight_rot,
+                                       az_branch=self.az_branch)
         else:
             return block
 

--- a/src/schedlib/thirdparty/avoidance.py
+++ b/src/schedlib/thirdparty/avoidance.py
@@ -80,10 +80,14 @@ class SunAvoidance(core.MappableRule):
     @apply_block.register(src.SourceBlock)
     def _(self, block):
         sun = get_sun_tracker(u.dt2ct(block.t0), policy=self.to_dict())
-        if hasattr(block ,'get_az_alt_limits'):
+        if hasattr(block ,'get_az_alt_extent'):
             # At each minute, assess sun-safety
-            t, az_left, az_right, alt = block.get_az_alt_limits(time_step=self.time_step * 60)
-            ok = np.zeros(len(t))
+            t, az_left, az_right, alt_min, alt_max = \
+                block.get_az_alt_extent(time_step=self.time_step * 60)
+            # Confirm alt is constant...
+            alt = alt_min[0]
+            assert np.all(alt == np.array([alt_max, alt_min]))
+            ok = np.zeros(len(t), bool)
             for _i in range(len(t)):
                 az = np.linspace(az_left[_i], az_right[_i], 101)
                 j, i = sun._azel_pix(az, alt, dt=t[_i]-sun.base_time)

--- a/src/schedlib/thirdparty/avoidance.py
+++ b/src/schedlib/thirdparty/avoidance.py
@@ -80,10 +80,20 @@ class SunAvoidance(core.MappableRule):
     @apply_block.register(src.SourceBlock)
     def _(self, block):
         sun = get_sun_tracker(u.dt2ct(block.t0), policy=self.to_dict())
-        t, az, alt = block.get_az_alt(time_step=self.time_step)
-        j, i = sun._azel_pix(az, alt, dt=t-sun.base_time)
-        sun_time = sun.sun_times[j, i]
-        ok = sun_time > self.min_sun_time
+        if hasattr(block ,'get_az_alt_limits'):
+            # At each minute, assess sun-safety
+            t, az_left, az_right, alt = block.get_az_alt_limits(time_step=self.time_step * 60)
+            ok = np.zeros(len(t))
+            for _i in range(len(t)):
+                az = np.linspace(az_left[_i], az_right[_i], 101)
+                j, i = sun._azel_pix(az, alt, dt=t[_i]-sun.base_time)
+                sun_time = sun.sun_times[j, i]
+                ok[_i] = (sun_time > self.min_sun_time).all()
+        else:
+            t, az, alt = block.get_az_alt(time_step=self.time_step)
+            j, i = sun._azel_pix(az, alt, dt=t-sun.base_time)
+            sun_time = sun.sun_times[j, i]
+            ok = sun_time > self.min_sun_time
 
         # find safe intervals
         n_buffer = self.cut_buffer // self.time_step


### PR DESCRIPTION
- When assessing scan Sun safety, add a bit of a buffer in azimuth to account for turn-arounds.
- Don't consider multiple az branch options for each action -- behavior is buggy.

This is not intended for merge -- just for testing / temporary use.

@kmharrington I believe this will resolve the odd Sun Avoidance conflicts (and the weird indentation #73) encountered recently, but please check it for general good behavior.