### PR TITLE
Add threshold to schedule start for error prevention

### DIFF
--- a/src/schedlib/commands.py
+++ b/src/schedlib/commands.py
@@ -374,7 +374,7 @@ def wait_until(state, t1: dt.datetime):
 @operation(name='start_time')
 def start_time(state):
     return state, [
-        f"run.wait_until('{state.curr_time.isoformat()}')"
+        f"run.wait_until('{state.curr_time.isoformat()}', tolerance=3600)"
     ]
 
 @operation(name="move_to", duration=0)


### PR DESCRIPTION
Add in tolerance around first `run.wait_until` in each schedule. This will prevent folks from accidentally starting a schedule intended for a time more than an hour away from the intended start. 