### PR TITLE
decompose move_to into separate az and el movements

### DIFF
--- a/src/schedlib/commands.py
+++ b/src/schedlib/commands.py
@@ -381,8 +381,16 @@ def start_time(state):
 def move_to(state, az, el, force=False):
     if not force and (state.az_now == az and state.el_now == el):
         return state, []
+
+    if el == state.el_now:
+        cmd = [f"run.acu.move_to(az={round(az, 3)}, el={(round(el, 3))})"]
+    else:
+        cmd = [
+            f"run.acu.move_to(az={round(az, 3)}, el={round(state.el_now, 3)})",
+            f"run.acu.move_to(az={round(az, 3)}, el={round(el, 3)})",
+        ]
     state = state.replace(az_now=az, el_now=el)
-    cmd = [f"run.acu.move_to(az={round(az, 3)}, el={round(el, 3)})"]
+
     return state, cmd
 
 @operation(name='set_scan_params', duration=0)


### PR DESCRIPTION
Currently both az and el change during move_to. #89 suggests changing that to two moves, with azimuth first and then elevation. This PR implements it. 