### PR TITLE
Safety checker script

### DIFF
--- a/scripts/sun_safety_checker.py
+++ b/scripts/sun_safety_checker.py
@@ -42,7 +42,8 @@ class SunCrawler:
         return az, el
 
     def _wait_parse(self, l):
-        time = datetime.datetime.fromisoformat(l.split("('")[1].rstrip("')\n")).timestamp()
+        t = l.split("('")[1].rstrip("')\n").split(",")[0].strip("'")
+        time = datetime.datetime.fromisoformat(t).timestamp()
         return time
 
     def _scan_parse(self, b, debug=False):

--- a/scripts/sun_safety_checker.py
+++ b/scripts/sun_safety_checker.py
@@ -9,7 +9,11 @@ import socs.agents.acu.avoidance as avoidance
 
 ## Code to check sun safety
 
-satp1_policy_info = {'az_limits': [-45, 405], 'min_sun_angle': 41, 'min_sun_time': 1980}
+satp1_policy_info = {
+    'az_limits': [-45, 405], 
+    'min_sun_angle': 41, 
+    'min_sun_time': 1980
+}
 
 parser = argparse.ArgumentParser()
 parser.add_argument('sched_path')
@@ -74,7 +78,7 @@ class SunCrawler:
 
         d1 = self.sungod.check_trajectory(init_az_range, [self.cur_el, self.cur_el], t=self.cur_time)
         d2 = self.sungod.check_trajectory(end_az_range, [self.cur_el, self.cur_el], t=stop)
-        assert((d1['sun_dist_min'] > self.satp1_policy['exclusion_radius']) and (d2['sun_dist_min'] > self.satp1_policy['exclusion_radius']))
+        assert((d1['sun_dist_min'] > self.policy['exclusion_radius']) and (d2['sun_dist_min'] > self.policy['exclusion_radius']))
 
         #print('Min scan distance to sun at start', d1['sun_dist_min'])
         print('Min scan distance to sun at end', d2['sun_dist_min'])
@@ -106,12 +110,12 @@ class SunCrawler:
                 break
 
     def _generate_sun_solution(self):
-        self.satp1_policy = avoidance.DEFAULT_POLICY
-        self.satp1_policy['min_el'] = 48.
-        self.satp1_policy['min_sun_time'] = satp1_policy_info['min_sun_time']
-        self.satp1_policy['exclusion_radius'] = satp1_policy_info['min_sun_angle']
+        self.policy = avoidance.DEFAULT_POLICY
+        self.policy['min_el'] = 48.
+        self.policy['min_sun_time'] = satp1_policy_info['min_sun_time']
+        self.policy['exclusion_radius'] = satp1_policy_info['min_sun_angle']
 
-        self.sungod = avoidance.SunTracker(policy=self.satp1_policy, base_time=self.cur_time, compute=True)
+        self.sungod = avoidance.SunTracker(policy=self.policy, base_time=self.cur_time, compute=True)
 
     def _test_sungod(self):
         out = self.sungod.get_sun_pos(t=self.cur_time+500.)
@@ -170,7 +174,7 @@ class SunCrawler:
                 #print(az_range, el_range)
                 d = self.sungod.check_trajectory(az_range, el_range, t=self.cur_time)
                 print('Min slew distance to sun', d['sun_dist_min'])
-                assert(d['sun_dist_min'] > self.satp1_policy['exclusion_radius'])
+                assert(d['sun_dist_min'] > self.policy['exclusion_radius'])
 
             if 'az = ' in l:
                 az = float(l.split('az = ')[1].split('+')[0])

--- a/scripts/sun_safety_checker.py
+++ b/scripts/sun_safety_checker.py
@@ -1,0 +1,202 @@
+#!/usr/bin/env python
+
+import numpy as np
+import argparse
+import datetime
+
+## Code to check sun safety
+
+satp1_policy_info = {'az_limits': [-45, 405], 'min_sun_angle': 41, 'min_sun_time': 1980}
+
+parser = argparse.ArgumentParser()
+parser.add_argument('sched_path')
+
+class SunCrawler:
+    def __init__(self, path):
+        self.schedf = open(path, 'r')
+
+        self.cur_time = 0
+        self.cur_az = 0
+        self.cur_el = 0
+
+        self._get_initial_pos()
+        self._generate_sun_solution()
+        #self._test_sungod()
+
+    def _move_to_parse(self, l):
+        try:
+            az = float(l.split('az=')[1].split(',')[0])
+        except IndexError:
+            print('Bad input!', l)
+            az = None
+
+        try:
+            el = float(l.split('el=')[1].rstrip(')\n'))
+        except IndexError:
+            try:
+                el = float(l.split(',')[1].rstrip(')\n'))
+            except IndexError:
+                print('Bad input!', l)
+                el = None
+
+        return az, el
+
+    def _wait_parse(self, l):
+        time = datetime.datetime.fromisoformat(l.split("('")[1].rstrip("')\n")).timestamp()
+        return time
+
+    def _scan_parse(self, b, debug=False):
+        #print(b)
+        planet_flag = np.any([('now = ' in l) for l in b]) or np.any([("'cal'" in l) for l in b])
+
+        start_time = self.cur_time
+        stop = 0.
+        width = 0.
+        drift = 0.
+        for l in b:
+            if 'stop_time' in l:
+                stop = datetime.datetime.fromisoformat(l.split("stop_time='")[1].rstrip("', \n")).timestamp()
+            if 'width' in l and 'drift' in l:
+                width = float(l.split(', ')[0].split('=')[1])
+                drift = float(l.split(', ')[1].split('=')[1].rstrip(', \n'))
+            elif 'width' in l and 'drift' not in l:
+                width = float(l.split('=')[1].rstrip(', \n'))
+            elif 'drift' in l and 'width' not in l:
+                drift = float(l.split('=')[1].rstrip(', \n'))
+                
+        init_az_range = [self.cur_az, self.cur_az + width]
+        drifted_az = self.cur_az + drift * (stop - self.cur_time)
+        end_az_range = [drifted_az, drifted_az + width]
+
+        d1 = self.sungod.check_trajectory(init_az_range, [self.cur_el, self.cur_el], t=self.cur_time)
+        d2 = self.sungod.check_trajectory(end_az_range, [self.cur_el, self.cur_el], t=stop)
+        assert((d1['sun_dist_min'] > self.satp1_policy['exclusion_radius']) and (d2['sun_dist_min'] > self.satp1_policy['exclusion_radius']))
+
+        #print('Min scan distance to sun at start', d1['sun_dist_min'])
+        print('Min scan distance to sun at end', d2['sun_dist_min'])
+
+        if debug:
+            print('azimuth : ', self.cur_az, ' --> ', drifted_az + width)
+            print('timestamp : ', self.cur_time, ' --> ', stop)
+        
+        self.cur_az = drifted_az + width
+        self.cur_time = stop
+
+    def _get_initial_pos(self):
+        time_flag = False
+        pos_flag = False
+        while True:
+            l = self.schedf.readline()
+            if 'move_to' in l:
+                az, el = self._move_to_parse(l)
+                self.cur_az = az
+                self.cur_el = el
+                pos_flag = True
+                
+            if 'wait_until' in l:
+                ts = self._wait_parse(l)
+                self.cur_time = ts
+                time_flag = True
+
+            if pos_flag and time_flag:
+                break
+
+    def _generate_sun_solution(self):
+        import sys
+        sys.path.append('/so/home/ktcrowley/repos/')
+        import socs.socs.agents.acu.avoidance as avoidance
+
+        self.satp1_policy = avoidance.DEFAULT_POLICY
+        self.satp1_policy['min_el'] = 48.
+        self.satp1_policy['min_sun_time'] = satp1_policy_info['min_sun_time']
+        self.satp1_policy['exclusion_radius'] = satp1_policy_info['min_sun_angle']
+
+        self.sungod = avoidance.SunTracker(policy=self.satp1_policy, base_time=self.cur_time, compute=True)
+
+    def _test_sungod(self):
+        out = self.sungod.get_sun_pos(t=self.cur_time+500.)
+        print(out)
+
+    def _get_traj(self, az, el):
+        if az == 0:
+            az = self.next_az
+
+        # catching wrap questions
+        if self.cur_az < 180 and az >= 180: # ccw wrap
+            mid_az = np.mean([self.cur_az, az])
+        elif self.cur_az > 180 and az <= 180: # cw wrap
+            mid_az = np.mean([self.cur_az, az])
+        else:
+            mid_az = az
+
+        mid_el = np.mean([self.cur_el, el])
+
+        return [self.cur_az, mid_az, az], [self.cur_el, mid_el, el]
+
+    def step_thru_schedule(self, debug=False):
+        cur_block = []
+        scan_flag = False
+        
+        while True:
+            l = self.schedf.readline()
+
+            if 'wait_until' in l:
+                ts = self._wait_parse(l)
+                if debug:
+                    print('timestamp: ', self.cur_time, ' --> ', ts)
+                self.cur_time = ts
+            
+            if 'move_to' in l:
+                az, el = self._move_to_parse(l)
+
+                if az is not None and el is not None:
+                    az_range, el_range = self._get_traj(az, el)
+                    if debug:
+                        print('azimuth :', self.cur_az, ' --> ', az)
+                        print('elevation :', self.cur_el, ' --> ', el)
+                    
+                    self.cur_az = az
+                    self.cur_el = el
+                elif el is not None:
+                    az_range, el_range = self._get_traj(0, el)
+
+                    if debug:
+                        print('azimuth :', self.cur_az, ' --> ', self.next_az)
+                        print('elevation :', self.cur_el, ' --> ', el)
+
+                    self.cur_az = self.next_az
+                    self.cur_el = el
+                    
+                #print(az_range, el_range)
+                d = self.sungod.check_trajectory(az_range, el_range, t=self.cur_time)
+                print('Min slew distance to sun', d['sun_dist_min'])
+                assert(d['sun_dist_min'] > self.satp1_policy['exclusion_radius'])
+
+            if 'az = ' in l:
+                az = float(l.split('az = ')[1].split('+')[0])
+                try:
+                    self.next_az = az
+                except AttributeError:
+                    self.next_az = 0.
+                    self.next_az = az
+
+            if 'run.seq.scan' in l:
+                assert(l[-2:] == '(\n')
+                scan_flag = True
+
+            if l.strip() == ')':
+                scan_flag = False
+                self._scan_parse(cur_block, debug=debug)
+                cur_block = []
+
+            if scan_flag:
+                cur_block.append(l)
+
+            if l == '':
+                break
+                
+
+if __name__ == "__main__":
+    args = parser.parse_args()
+    sc = SunCrawler(args.sched_path)
+    sc.step_thru_schedule(debug=True)

--- a/scripts/sun_safety_checker.py
+++ b/scripts/sun_safety_checker.py
@@ -4,6 +4,9 @@ import numpy as np
 import argparse
 import datetime
 
+## going to require the actual agent code here
+import socs.agents.acu.avoidance as avoidance
+
 ## Code to check sun safety
 
 satp1_policy_info = {'az_limits': [-45, 405], 'min_sun_angle': 41, 'min_sun_time': 1980}
@@ -103,10 +106,6 @@ class SunCrawler:
                 break
 
     def _generate_sun_solution(self):
-        import sys
-        sys.path.append('/so/home/ktcrowley/repos/')
-        import socs.socs.agents.acu.avoidance as avoidance
-
         self.satp1_policy = avoidance.DEFAULT_POLICY
         self.satp1_policy['min_el'] = 48.
         self.satp1_policy['min_sun_time'] = satp1_policy_info['min_sun_time']

--- a/src/schedlib/quality_assurance/__init__.py
+++ b/src/schedlib/quality_assurance/__init__.py
@@ -1,0 +1,1 @@
+from .sun_safety_checker import SunCrawler

--- a/src/schedlib/quality_assurance/sun_safety_checker.py
+++ b/src/schedlib/quality_assurance/sun_safety_checker.py
@@ -5,8 +5,9 @@ import argparse
 import datetime
 
 ## going to require the actual agent code here
+import sys
+sys.path.append('/so/home/ktcrowley/repos/socs')
 import socs.agents.acu.avoidance as avoidance
-
 
 import schedlib.utils as u
 logger = u.init_logger(__name__)
@@ -64,7 +65,7 @@ class SunCrawler:
             self.cmd_n += 1
             return self.cmd_list[self.cmd_n-1]+"\n"
         else:
-            return schedf.readline()
+            return self.schedf.readline()
 
 
     def _move_to_parse(self, l):
@@ -116,8 +117,8 @@ class SunCrawler:
         
         d1 = self.sungod.check_trajectory(init_az_range, [self.cur_el, self.cur_el], t=self.cur_time)
         d2 = self.sungod.check_trajectory(end_az_range, [self.cur_el, self.cur_el], t=stop)
-        assert((d1['sun_dist_min'] > self.satp1_policy['exclusion_radius']) and (d2['sun_dist_min'] > self.satp1_policy['exclusion_radius']))
-        assert((d1['sun_time'] > self.satp1_policy['min_sun_time']) and (d2['sun_time'] > self.satp1_policy['min_sun_time']))
+        assert((d1['sun_dist_min'] > self.policy['exclusion_radius']) and (d2['sun_dist_min'] > self.policy['exclusion_radius']))
+        assert((d1['sun_time'] > self.policy['min_sun_time']) and (d2['sun_time'] > self.policy['min_sun_time']))
 
         #print('Min scan distance to sun at start', d1['sun_dist_min'])
         print('Min scan distance to sun at end', d2['sun_dist_min'])
@@ -240,7 +241,7 @@ class SunCrawler:
                 logger.info(f"Min slew distance to sun {d['sun_dist_min']}")
                 assert(d['sun_dist_min'] > self.policy['exclusion_radius'])
                 logger.info(f"Min sun clear time {d['sun_time']}")
-                assert(d['sun_time'] > self.satp1_policy['min_sun_time'])
+                assert(d['sun_time'] > self.policy['min_sun_time'])
 
                 moves = self.sungod.analyze_paths(az_range[0], el_range[0], az_range[-1], el_range[-1], t=self.cur_time)
                 move, decisions = self.sungod.select_move(moves)

--- a/src/schedlib/quality_assurance/sun_safety_checker.py
+++ b/src/schedlib/quality_assurance/sun_safety_checker.py
@@ -61,9 +61,12 @@ class SunCrawler:
             if self.cmd_n == len(self.cmd_list):
                 return ''
             self.cmd_n += 1
-            return self.cmd_list[self.cmd_n-1]+"\n"
+            l = self.cmd_list[self.cmd_n-1]+"\n"
         else:
-            return self.schedf.readline()
+            l = self.schedf.readline()
+        if len(l)>0 and l[0] == "#":
+            return self.next_line()
+        return l
 
 
     def _move_to_parse(self, l):
@@ -245,13 +248,17 @@ class SunCrawler:
                 move, decisions = self.sungod.select_move(moves)
                 try:
                     assert(move is not None)
-                except AssertionError:
+                except AssertionError as e:
                     out = self.sungod.get_sun_pos(t=self.cur_time)
                     logger.info(f'Sun position at failure time {out}')
                     logger.error('Sun-safe motions not solved!')
+                    t = datetime.datetime.utcfromtimestamp(self.cur_time)
+                    logger.error(
+                        f"Error on Line \'{l}\' at time {t.isoformat()}"
+                    )
                     logger.error('Move info (min sun dist, min sun time, min el, max el):')
                     logger.error('\n'.join([', '.join(map(str, [m['sun_dist_min'], m['sun_time'], min(m['moves'].get_traj(res=1.0)[1]), max(m['moves'].get_traj(res=1.0)[1])])) for m in moves]))
-                    break
+                    raise(e)
 
             if 'az = ' in l:
                 az = float(l.split('az = ')[1].split('+')[0])

--- a/src/schedlib/quality_assurance/sun_safety_checker.py
+++ b/src/schedlib/quality_assurance/sun_safety_checker.py
@@ -5,8 +5,6 @@ import argparse
 import datetime
 
 ## going to require the actual agent code here
-import sys
-sys.path.append('/so/home/ktcrowley/repos/socs')
 import socs.agents.acu.avoidance as avoidance
 
 import schedlib.utils as u


### PR DESCRIPTION
I've made a first pass at defining a class that can parse scheduler output .py files and determine if the specified moves, at the specified times, are actually sun-safe according to `socs.agents.acu.avoidance` module, specifically the command `check_trajectory`.

I'm still working to confirm this will catch all of the `No sun-safe moves!` or `That move violates sun safety` errors that have been crashing schedules on SATps in the past couple of months. The most recent such failure is caught (schedule beginning 20240916), but at least 1 other (schedule beginning 20240903) seems to pass -- so `check_trajectory` may not be the full story.