### PR TITLE
Replace `smurf.zero_biases` with sorunlib implementation

### DIFF
--- a/src/schedlib/policies/sat.py
+++ b/src/schedlib/policies/sat.py
@@ -138,10 +138,7 @@ def ufm_relock(state, commands=None):
         if commands is None:
             commands = [
                 "############# Daily Relock",
-                "for smurf in pysmurfs:",
-                "    smurf.zero_biases.start()",
-                "for smurf in pysmurfs:",
-                "    smurf.zero_biases.wait()",
+                "run.smurf.zero_biases()",
                 "",
                 "time.sleep(120)",
                 "run.smurf.take_noise(concurrent=True, tag='res_check')",

--- a/src/schedlib/policies/satp3.py
+++ b/src/schedlib/policies/satp3.py
@@ -163,10 +163,7 @@ def make_blocks(master_file):
 
 commands_uxm_relock = [
     "############# Daily Relock",
-    "for smurf in pysmurfs:",
-    "    smurf.zero_biases.start()",
-    "for smurf in pysmurfs:",
-    "    smurf.zero_biases.wait()",
+    "run.smurf.zero_biases()",
     "",
     "time.sleep(120)",
     "run.smurf.take_noise(concurrent=True, tag='res_check')",


### PR DESCRIPTION
This was added in sorunlib v0.1.10 [1]. The sorunlib implementation should be preferred as it also includes error handling.

[1] - https://github.com/simonsobs/sorunlib/releases/tag/v0.1.10