### PR TITLE
add ability to change elevation of sun parking spot

### DIFF
--- a/src/schedlib/policies/satp1.py
+++ b/src/schedlib/policies/satp1.py
@@ -223,7 +223,11 @@ def make_config(
         **op_cfg
     )
 
-    sun_policy = { 'min_angle': 41, 'min_sun_time': 1980 }
+    sun_policy = {
+        'min_angle': 41,
+        'min_sun_time': 1980,
+        'min_el': 48,
+    }
 
     config = {
         'blocks': blocks,

--- a/src/schedlib/policies/satp2.py
+++ b/src/schedlib/policies/satp2.py
@@ -224,7 +224,11 @@ def make_config(
         **op_cfg
     )
 
-    sun_policy = { 'min_angle': 49, 'min_sun_time': 1980 }
+    sun_policy = {
+        'min_angle': 49,
+        'min_sun_time': 1980,
+        'min_el': 48,
+    }
 
     config = {
         'blocks': blocks,

--- a/src/schedlib/policies/satp3.py
+++ b/src/schedlib/policies/satp3.py
@@ -241,7 +241,11 @@ def make_config(
     if boresight_override is not None:
         logger.warning("Boresight Override does nothing for SATp3")
 
-    sun_policy = { 'min_angle': 49, 'min_sun_time': 1980 }
+    sun_policy = {
+        'min_angle': 49,
+        'min_sun_time': 1980,
+        'min_el': 48,
+    }
 
     config = {
         'blocks': blocks,

--- a/src/schedlib/policies/stages/build_op.py
+++ b/src/schedlib/policies/stages/build_op.py
@@ -667,9 +667,15 @@ class PlanMoves:
                 t0_parking = t1_parking \
                     = block0.t1 + (block1.t0 - block0.t1) / 2
             else:
-                if get_traj_ok_time(az_parking, az_parking, alt_parking, alt_parking,
-                                    t0_parking) < t1_parking:
-                    raise ValueError("Sun-safe parking spot not found.")
+                safet = get_traj_ok_time(az_parking, az_parking, alt_parking, alt_parking,
+                                         t0_parking)
+                if safet< t1_parking:
+                    alt_parking = self.sun_policy['min_el']
+                    safet = get_traj_ok_time(az_parking, az_parking, alt_parking, alt_parking,
+                                             t0_parking)
+                    if safet< t1_parking:
+                        raise ValueError(f"Sun-safe parking spot not found. az {az_parking} "
+                                         f"el {alt_parking} is safe only until {safet}")
 
             # Verify we can get to the parking spot, and get out of it.
             if get_traj_ok_time(block0.az, az_parking, block0.alt, alt_parking,


### PR DESCRIPTION
To resolve https://github.com/simonsobs/scheduler/issues/111
Add ability to change elevation of sun parking spot. This is critical for operation in the Chilean summer with larger sun avoidance. We configure the minimum allowed elevation in each policy. Also, added more info in the error log.

This will change the sun avoidace part of schedule like this, if it is necessary to change elevation.
```
run.wait_until('2024-10-07T14:48:24+00:00')
run.acu.move_to(az=180.0, el=60.0)
run.acu.move_to(az=180.0, el=48)
run.wait_until('2024-10-07T14:53:24+00:00')
run.acu.move_to(az=180.0, el=48)
run.wait_until('2024-10-07T18:57:35.980000+00:00')
run.acu.move_to(az=111.483, el=48)
run.acu.move_to(az=111.483, el=60.0)
run.wait_until('2024-10-07T19:02:35.980000+00:00')
run.acu.move_to(az=111.483, el=60.0)
```