### PR TITLE
add bgmap in satp3 policy

### DIFF
--- a/src/schedlib/policies/satp3.py
+++ b/src/schedlib/policies/satp3.py
@@ -176,6 +176,7 @@ commands_uxm_relock = [
 commands_det_setup = [
     "",
     "################### Detector Setup######################",
+    "run.smurf.take_bgmap(concurrent=True)",
     "run.smurf.iv_curve(concurrent=True)",
     "for smurf in pysmurfs:",
     "    smurf.bias_dets.start(rfrac=0.5, kwargs=dict(bias_groups=[0,1,2,3,4,5,6,7,8,9,10,11]))",


### PR DESCRIPTION
We have not been including bgmap in our det_setup because it is only necessary right after the relock, strictly speaking.
But we discussed that it would be helpful to have it in det_setup in similar way as satp1, to avoid mistake of not running bgmap after hammering the readout slot. Also because bg map takes only for a very short period of time ~ few seconds.