### PR TITLE
Change relock block in satp3 policy so take_noise done while detector…

### DIFF
--- a/src/schedlib/policies/satp3.py
+++ b/src/schedlib/policies/satp3.py
@@ -162,10 +162,7 @@ def make_blocks(master_file):
     }
 
 commands_uxm_relock = [
-    "############# Daily Relock",
-    "run.smurf.zero_biases()",
-    "",
-    "time.sleep(120)",
+    "############# Daily Relock",  
     "run.smurf.take_noise(concurrent=True, tag='res_check')",
     "run.smurf.uxm_relock(concurrent=True)",
     "run.smurf.take_bgmap(concurrent=True)",
@@ -178,6 +175,7 @@ commands_det_setup = [
     "################### Detector Setup######################",
     "with disable_trace():",
     "    run.initialize()",
+    "pysmurfs = run.CLIENTS['smurf']",
     "run.smurf.take_bgmap(concurrent=True)",
     "run.smurf.iv_curve(concurrent=True)",
     "for smurf in pysmurfs:",


### PR DESCRIPTION
Change relock block to take noise while detectors are in transition (don't zero bias), relock automatically takes SC noise so we will have a check on both. Add re-definition of pysmurfs in det setup block so that UFMs that are re-introduced after failure will be successfully biased.