### PR TITLE
Update wrap up move command and change all moves to single command

### DIFF
--- a/src/schedlib/commands.py
+++ b/src/schedlib/commands.py
@@ -381,12 +381,8 @@ def start_time(state):
 def move_to(state, az, el, force=False):
     if not force and (state.az_now == az and state.el_now == el):
         return state, []
-
-    if el == state.el_now:
-        cmd = [f"run.acu.move_to(az={round(az, 3)}, el={(round(el, 3))})"]
     else:
         cmd = [
-            f"run.acu.move_to(az={round(az, 3)}, el={round(state.el_now, 3)})",
             f"run.acu.move_to(az={round(az, 3)}, el={round(el, 3)})",
         ]
     state = state.replace(az_now=az, el_now=el)

--- a/src/schedlib/policies/sat.py
+++ b/src/schedlib/policies/sat.py
@@ -366,11 +366,8 @@ def bias_step(state, block, bias_step_cadence=None):
         return state, 0, []
 
 @cmd.operation(name='sat.wrap_up', duration=0)
-def wrap_up(state, az_stow, el_stow):
-    state = state.replace(az_now=az_stow, el_now=el_stow)
+def wrap_up(state):
     return state, [
-        #"# go home",
-        #f"run.acu.move_to(az={az_stow}, el={el_stow})",
         "time.sleep(1)"
     ]
 

--- a/src/schedlib/policies/sat.py
+++ b/src/schedlib/policies/sat.py
@@ -168,6 +168,7 @@ def hwp_spin_up(state, disable_hwp=False, forward=True):
             f"run.hwp.set_freq(freq={freq})",
         ]
 
+
 @cmd.operation(name='sat.hwp_spin_down', return_duration=True)
 def hwp_spin_down(state, disable_hwp=False):
     if disable_hwp:
@@ -370,8 +371,8 @@ def bias_step(state, block, bias_step_cadence=None):
 def wrap_up(state, az_stow, el_stow):
     state = state.replace(az_now=az_stow, el_now=el_stow)
     return state, [
-        "# go home",
-        f"run.acu.move_to(az={az_stow}, el={el_stow})",
+        #"# go home",
+        #f"run.acu.move_to(az={az_stow}, el={el_stow})",
         "time.sleep(1)"
     ]
 

--- a/src/schedlib/policies/satp1.py
+++ b/src/schedlib/policies/satp1.py
@@ -202,7 +202,7 @@ def make_operations(
     if home_at_end:
         post_session_ops = [
             { 'name': 'sat.hwp_spin_down'   , 'sched_mode': SchedMode.PostSession, 'disable_hwp': disable_hwp, },
-            { 'name': 'sat.wrap_up'         , 'sched_mode': SchedMode.PostSession, 'az_stow': 180, 'el_stow': 48},
+            { 'name': 'sat.wrap_up'         , 'sched_mode': SchedMode.PostSession},
         ]
     else:
         post_session_ops = []
@@ -235,6 +235,11 @@ def make_config(
         'min_el': 48,
     }
 
+    stow_position = {
+        'az_stow': 180,
+        'el_stow': 48,
+    }
+
     config = {
         'blocks': blocks,
         'geometries': geometries,
@@ -248,15 +253,16 @@ def make_config(
         'cal_targets': cal_targets,
         'scan_tag': None,
         'boresight_override': boresight_override,
-        'az_speed' : az_speed,
-        'az_accel' : az_accel,
-        'iv_cadence' : iv_cadence,
-        'bias_step_cadence' : bias_step_cadence,
-        'min_hwp_el' : min_hwp_el,
-        'max_cmb_scan_duration' : max_cmb_scan_duration,
+        'az_speed': az_speed,
+        'az_accel': az_accel,
+        'iv_cadence': iv_cadence,
+        'bias_step_cadence': bias_step_cadence,
+        'min_hwp_el': min_hwp_el,
+        'max_cmb_scan_duration': max_cmb_scan_duration,
         'stages': {
             'build_op': {
                 'plan_moves': {
+                    'stow_position': stow_position,
                     'sun_policy': sun_policy,
                     'az_step': 0.5,
                     'az_limits': [-45, 405],

--- a/src/schedlib/policies/satp2.py
+++ b/src/schedlib/policies/satp2.py
@@ -203,7 +203,7 @@ def make_operations(
     if home_at_end:
         post_session_ops = [
             { 'name': 'sat.hwp_spin_down'   , 'sched_mode': SchedMode.PostSession, 'disable_hwp': disable_hwp, },
-            { 'name': 'sat.wrap_up'         , 'sched_mode': SchedMode.PostSession, 'az_stow': 180, 'el_stow': 40},
+            { 'name': 'sat.wrap_up'         , 'sched_mode': SchedMode.PostSession},
         ]
     else:
         post_session_ops = []
@@ -236,6 +236,11 @@ def make_config(
         'min_el': 40,
     }
 
+    stow_position = {
+        'az_stow': 180,
+        'el_stow': 40,
+    }
+
     config = {
         'blocks': blocks,
         'geometries': geometries,
@@ -258,6 +263,7 @@ def make_config(
         'stages': {
             'build_op': {
                 'plan_moves': {
+                    'stow_position': stow_position,
                     'sun_policy': sun_policy,
                     'az_step': 0.5,
                     'az_limits': [-45, 405],
@@ -287,7 +293,7 @@ class SATP2Policy(SATPolicy):
         state_file=None, **op_cfg
     ):
         x = cls(**make_config(
-            master_file, az_speed, az_accel, 
+            master_file, az_speed, az_accel,
             iv_cadence, bias_step_cadence, min_hwp_el,
             max_cmb_scan_duration, cal_targets,
             boresight_override, **op_cfg

--- a/src/schedlib/policies/satp3.py
+++ b/src/schedlib/policies/satp3.py
@@ -220,7 +220,7 @@ def make_operations(
     if home_at_end:
         post_session_ops = [
             { 'name': 'sat.hwp_spin_down'   , 'sched_mode': SchedMode.PostSession, 'disable_hwp': disable_hwp, },
-            { 'name': 'sat.wrap_up'         , 'sched_mode': SchedMode.PostSession, 'az_stow': 180, 'el_stow': 40},
+            { 'name': 'sat.wrap_up'         , 'sched_mode': SchedMode.PostSession},
         ]
     else:
         post_session_ops = []
@@ -256,6 +256,11 @@ def make_config(
         'min_el': 40,
     }
 
+    stow_position = {
+        'az_stow': 180,
+        'el_stow': 40,
+    }
+
     config = {
         'blocks': blocks,
         'geometries': geometries,
@@ -268,15 +273,16 @@ def make_config(
         'operations': operations,
         'cal_targets': cal_targets,
         'scan_tag': None,
-        'az_speed' : az_speed,
-        'az_accel' : az_accel,
-        'iv_cadence' : iv_cadence,
-        'bias_step_cadence' : bias_step_cadence,
-        'min_hwp_el' : min_hwp_el,
-        'max_cmb_scan_duration' : max_cmb_scan_duration,
+        'az_speed': az_speed,
+        'az_accel': az_accel,
+        'iv_cadence': iv_cadence,
+        'bias_step_cadence': bias_step_cadence,
+        'min_hwp_el': min_hwp_el,
+        'max_cmb_scan_duration': max_cmb_scan_duration,
         'stages': {
             'build_op': {
                 'plan_moves': {
+                    'stow_position': stow_position,
                     'sun_policy': sun_policy,
                     'az_step': 0.5,
                     'az_limits': [-45, 405],

--- a/src/schedlib/policies/stages/build_op.py
+++ b/src/schedlib/policies/stages/build_op.py
@@ -386,15 +386,13 @@ class BuildOp:
         logger.info("step 4: planning post-session ops")
 
         ops = [op for op in operations if op['sched_mode'] == SchedMode.PostSession]
-        az_stow = [op['az_stow'] for op in ops if 'az_stow' in op][0]
-        alt_stow = [op['el_stow'] for op in ops if 'el_stow' in op][0]
-
         state, post_dur, _ = self._apply_ops(state, ops)
         ir += [
             IR(name='post_session', subtype=IRMode.PostSession,
                t0=state.curr_time-dt.timedelta(seconds=post_dur),
                t1=state.curr_time, operations=ops,
-               az=az_stow, alt=alt_stow)
+               az=self.plan_moves['stow_position']['az_stow'],
+               alt=self.plan_moves['stow_position']['el_stow'])
         ]
         logger.debug(f"post-session state: {state}")
 
@@ -694,6 +692,7 @@ class BuildOp:
 class PlanMoves:
     """solve moves to make seq possible"""
     sun_policy: Dict[str, Any]
+    stow_position: Dict[str, Any]
     az_step: float = 1
     az_limits: Tuple[float, float] = (-90, 450)
 


### PR DESCRIPTION
This pull request aims to address #96 by removing the move command from the `sat.wrap_up` operation and treating the post-session IR as a regular block similar to cmb or source scans.  This should also address #122, by removing the 2 individual az-only or el-only move commands and making a single az/el move for all move commands.