### PR TITLE
Add Az wrapping for calib obs if scan goes out of Az bounds

### DIFF
--- a/src/schedlib/policies/sat.py
+++ b/src/schedlib/policies/sat.py
@@ -625,6 +625,12 @@ class SATPolicy:
             rule = ru.make_rule('min-duration', **self.rules['min-duration'])
             blocks['baseline'] = rule(blocks['baseline'])
 
+        # az range rule
+        if 'az-range' in self.rules:
+            logger.info(f"applying az range rule: {self.rules['az-range']}")
+            az_range = ru.AzRange(**self.rules['az-range'])
+            blocks['calibration'] = az_range(blocks['calibration'])
+
         # -----------------------------------------------------------------
         # step 4: tags
         # -----------------------------------------------------------------

--- a/src/schedlib/policies/satp1.py
+++ b/src/schedlib/policies/satp1.py
@@ -235,6 +235,11 @@ def make_config(
         'min_el': 48,
     }
 
+    az_range = {
+        'trim': False,
+        'az_range': [-45, 405]
+    }
+
     config = {
         'blocks': blocks,
         'geometries': geometries,
@@ -243,6 +248,7 @@ def make_config(
                 'min_duration': 600
             },
             'sun-avoidance': sun_policy,
+            'az-range': az_range,
         },
         'operations': operations,
         'cal_targets': cal_targets,
@@ -259,7 +265,7 @@ def make_config(
                 'plan_moves': {
                     'sun_policy': sun_policy,
                     'az_step': 0.5,
-                    'az_limits': [-45, 405],
+                    'az_limits': az_range['az_range'],
                 }
             }
         }

--- a/src/schedlib/policies/satp2.py
+++ b/src/schedlib/policies/satp2.py
@@ -236,6 +236,11 @@ def make_config(
         'min_el': 40,
     }
 
+    az_range = {
+        'trim': False,
+        'az_range': [-45, 405]
+    }
+
     config = {
         'blocks': blocks,
         'geometries': geometries,
@@ -244,6 +249,7 @@ def make_config(
                 'min_duration': 600
             },
             'sun-avoidance': sun_policy,
+            'az-range': az_range
         },
         'operations': operations,
         'cal_targets': cal_targets,
@@ -260,7 +266,7 @@ def make_config(
                 'plan_moves': {
                     'sun_policy': sun_policy,
                     'az_step': 0.5,
-                    'az_limits': [-45, 405],
+                    'az_limits': az_range['az_range'],
                 }
             }
         }

--- a/src/schedlib/policies/satp3.py
+++ b/src/schedlib/policies/satp3.py
@@ -256,6 +256,11 @@ def make_config(
         'min_el': 40,
     }
 
+    az_range = {
+        'trim': False,
+        'az_range': [-45, 405]
+    }
+
     config = {
         'blocks': blocks,
         'geometries': geometries,
@@ -264,6 +269,7 @@ def make_config(
                 'min_duration': 600
             },
             'sun-avoidance': sun_policy,
+            'az-range': az_range,
         },
         'operations': operations,
         'cal_targets': cal_targets,
@@ -279,7 +285,7 @@ def make_config(
                 'plan_moves': {
                     'sun_policy': sun_policy,
                     'az_step': 0.5,
-                    'az_limits': [-45, 405],
+                    'az_limits': az_range['az_range'],
                 }
             }
         }

--- a/src/schedlib/policies/stages/build_op.py
+++ b/src/schedlib/policies/stages/build_op.py
@@ -336,16 +336,6 @@ class BuildOp:
         # re-merge all blocks
         all_blocks = core.seq_sort(core.seq_merge(cmb_blocks, cal_blocks, flatten=True))
 
-        # prevent obs from going outside of the allowed range by wrapping around
-        # these are not caught by find_unwrap which only checks the first value
-        for i, block in enumerate(all_blocks):
-            az1 = block.az + block.az_drift * (block.duration).total_seconds()
-
-            if az1 < self.plan_moves['az_limits'][0]:
-                all_blocks[i] = block.replace(az=block.az + 360)
-            elif az1 > self.plan_moves['az_limits'][1]:
-                all_blocks[i] = block.replace(az=block.az - 360)
-
         # done with previously planned operation seqs
         # re-plan from the end of initialization.
         state = post_init_state

--- a/src/schedlib/policies/stages/build_op.py
+++ b/src/schedlib/policies/stages/build_op.py
@@ -336,6 +336,16 @@ class BuildOp:
         # re-merge all blocks
         all_blocks = core.seq_sort(core.seq_merge(cmb_blocks, cal_blocks, flatten=True))
 
+        # prevent obs from going outside of the allowed range by wrapping around
+        # these are not caught by find_unwrap which only checks the first value
+        for i, block in enumerate(all_blocks):
+            az1 = block.az + block.az_drift * (block.duration).total_seconds()
+
+            if az1 < self.plan_moves['az_limits'][0]:
+                all_blocks[i] = block.replace(az=block.az + 360)
+            elif az1 > self.plan_moves['az_limits'][1]:
+                all_blocks[i] = block.replace(az=block.az - 360)
+
         # done with previously planned operation seqs
         # re-plan from the end of initialization.
         state = post_init_state


### PR DESCRIPTION
Uses and adjusts the existing `AzRange` rule to update the Az values of calibration observations if the given Az drift results in the scan going out of the specified Az bounds.