### PR TITLE
Add auto finding of sun-safe home

### DIFF
--- a/src/schedlib/policies/satp1.py
+++ b/src/schedlib/policies/satp1.py
@@ -218,6 +218,8 @@ def make_config(
     min_hwp_el,
     max_cmb_scan_duration,
     cal_targets,
+    az_stow=None,
+    el_stow=None,
     boresight_override=None,
     **op_cfg
 ):
@@ -235,10 +237,13 @@ def make_config(
         'min_el': 48,
     }
 
-    stow_position = {
-        'az_stow': 180,
-        'el_stow': 48,
-    }
+    if az_stow is None or el_stow is None:
+        stow_position = {}
+    else:
+        stow_position = {
+            'az_stow': az_stow,
+            'el_stow': el_stow,
+        }
 
     az_range = {
         'trim': False,
@@ -294,13 +299,14 @@ class SATP1Policy(SATPolicy):
     def from_defaults(cls, master_file, az_speed=0.8, az_accel=1.5,
         iv_cadence=4*u.hour, bias_step_cadence=0.5*u.hour,
         min_hwp_el=48, max_cmb_scan_duration=1*u.hour,
-        cal_targets=[], boresight_override=None,
+        cal_targets=[], az_stow=None, el_stow=None,
+        boresight_override=None,
         state_file=None, **op_cfg
     ):
         x = cls(**make_config(
             master_file, az_speed, az_accel, iv_cadence,
             bias_step_cadence, min_hwp_el, max_cmb_scan_duration,
-            cal_targets, boresight_override, **op_cfg
+            cal_targets, az_stow, el_stow, boresight_override, **op_cfg
         ))
         x.state_file=state_file
         return x

--- a/src/schedlib/policies/satp2.py
+++ b/src/schedlib/policies/satp2.py
@@ -219,6 +219,8 @@ def make_config(
     min_hwp_el,
     max_cmb_scan_duration,
     cal_targets,
+    az_stow=None,
+    el_stow=None,
     boresight_override=None,
     **op_cfg
 ):
@@ -236,10 +238,13 @@ def make_config(
         'min_el': 40,
     }
 
-    stow_position = {
-        'az_stow': 180,
-        'el_stow': 40,
-    }
+    if az_stow is None or el_stow is None:
+        stow_position = {}
+    else:
+        stow_position = {
+            'az_stow': az_stow,
+            'el_stow': el_stow,
+        }
 
     az_range = {
         'trim': False,
@@ -295,13 +300,15 @@ class SATP2Policy(SATPolicy):
     def from_defaults(cls, master_file, az_speed=0.8, az_accel=1.5,
         iv_cadence=4*u.hour, bias_step_cadence=0.5*u.hour,
         min_hwp_el=48, max_cmb_scan_duration=1*u.hour,
-        cal_targets=[], boresight_override=None,
+        cal_targets=[], az_stow=None, el_stow=None,
+        boresight_override=None,
         state_file=None, **op_cfg
     ):
         x = cls(**make_config(
             master_file, az_speed, az_accel,
             iv_cadence, bias_step_cadence, min_hwp_el,
             max_cmb_scan_duration, cal_targets,
+            az_stow, el_stow,
             boresight_override, **op_cfg
         ))
         x.state_file=state_file

--- a/src/schedlib/policies/satp3.py
+++ b/src/schedlib/policies/satp3.py
@@ -236,6 +236,8 @@ def make_config(
     min_hwp_el,
     max_cmb_scan_duration,
     cal_targets,
+    az_stow=None,
+    el_stow=None,
     boresight_override=None,
     **op_cfg
 ):
@@ -256,10 +258,13 @@ def make_config(
         'min_el': 40,
     }
 
-    stow_position = {
-        'az_stow': 180,
-        'el_stow': 40,
-    }
+    if az_stow is None or el_stow is None:
+        stow_position = {}
+    else:
+        stow_position = {
+            'az_stow': az_stow,
+            'el_stow': el_stow,
+        }
 
     az_range = {
         'trim': False,
@@ -312,13 +317,14 @@ class SATP3Policy(SATPolicy):
     def from_defaults(cls, master_file, az_speed=0.5, az_accel=0.25,
         iv_cadence=4*u.hour, bias_step_cadence=0.5*u.hour,
         min_hwp_el=48, max_cmb_scan_duration=1*u.hour,
-        cal_targets=[], state_file=None, **op_cfg
+        cal_targets=[], az_stow=None, el_stow=None,
+        state_file=None, **op_cfg
     ):
         x = cls(**make_config(
             master_file, az_speed, az_accel,
             iv_cadence, bias_step_cadence, min_hwp_el,
             max_cmb_scan_duration,
-            cal_targets, **op_cfg)
+            cal_targets, az_stow, el_stow, **op_cfg)
         )
         x.state_file = state_file
         return x

--- a/src/schedlib/policies/stages/build_op.py
+++ b/src/schedlib/policies/stages/build_op.py
@@ -427,20 +427,19 @@ class BuildOp:
 
         if len(ops) > 0:
             # find an alt, az that is sun-safe for the entire duration of the schedule.
-            # starts with the initial altaz given in the config
-            az = self.plan_moves['stow_position']['az_stow']
-            alt = self.plan_moves['stow_position']['el_stow']
-
-            # allow for calculation of sun safe stow position to be overidden in config
-            if az is None and alt is None:
+            if not self.plan_moves['stow_position']:
                 az = 180
                 alt = 60
                 # add a buffer to start and end to be safe
                 t_start = t0 - dt.timedelta(seconds=300)
                 t_end = t1 + dt.timedelta(seconds=300)
                 az, alt, _, _ = get_parking(t_start, t_end, az, alt, self.plan_moves['sun_policy'], az)
-
-            logger.info(f"found sun safe stow position at ({az}, {alt})")
+                logger.info(f"found sun safe stow position at ({az}, {alt})")
+            # allow for overriding of stow position from config
+            else:
+                az = self.plan_moves['stow_position']['az_stow']
+                alt = self.plan_moves['stow_position']['el_stow']
+                logger.info(f"using specified stow position at ({az}, {alt})")
         else:
             az = all_blocks[-1].az
             alt = all_blocks[-1].alt

--- a/src/schedlib/policies/stages/build_op.py
+++ b/src/schedlib/policies/stages/build_op.py
@@ -16,9 +16,11 @@ from schedlib import core, commands as cmd, utils as u, rules as ru
 from schedlib.thirdparty.avoidance import get_sun_tracker
 from schedlib.commands import SchedMode
 
+logger = u.init_logger(__name__)
+
 def get_traj_ok_time(az0, az1, alt0, alt1, t0, sun_policy):
-    #Returns the timestamp until which the move from
-    #(az0, alt0) to (az1, alt1) is sunsafe.
+    # Returns the timestamp until which the move from
+    # (az0, alt0) to (az1, alt1) is sunsafe.
     sun_tracker = get_sun_tracker(u.dt2ct(t0), policy=sun_policy)
     az = np.linspace(az0, az1, 101)
     el = np.linspace(alt0, alt1, 101)
@@ -29,7 +31,29 @@ def get_traj_ok_time(az0, az1, alt0, alt1, t0, sun_policy):
     sun_safety = sun_tracker.check_trajectory(t=u.dt2ct(t0), az=az, el=el)
     return u.ct2dt(u.dt2ct(t0) + sun_safety['sun_time'])
 
-logger = u.init_logger(__name__)
+def get_parking(t0, t1, az0, alt0, sun_policy, az_parking=180):
+    # gets a safe parking location for the time range and
+    # Do the move in two steps, parking at az=180 (most likely
+    # to be sun-safe).  Identify a spot that is safe for the
+    # duration of t0 to t1.
+    alt_range = alt0, sun_policy['min_el']
+    n_alts = max(2, int(round(abs(alt_range[1] - alt_range[0]) / 4. + 1)))
+    for alt_parking in np.linspace(alt_range[0], alt_range[1], n_alts):
+        safet = get_traj_ok_time(az_parking, az_parking, alt_parking, alt_parking,
+                                    t0, sun_policy)
+        if safet >= t1:
+            break
+    else:
+        raise ValueError(f"Sun-safe parking spot not found. az {az_parking} "
+                            f"el {alt_parking} is safe only until {safet}")
+
+    # Now bracket the moves, hopefully with ~5 minutes on each end.
+    buffer_t = min(300, int((t1 - t0).total_seconds() / 2))
+    t0_parking = t0 + dt.timedelta(seconds=buffer_t)
+    t1_parking = t1 - dt.timedelta(seconds=buffer_t)
+
+    return az_parking, alt_parking, t0_parking, t1_parking
+
 # some additional auxilary command classes that will be mixed 
 # into the IR to represent some intermediate operations. They
 # don't need to contain all the fields of a regular IR
@@ -402,8 +426,21 @@ class BuildOp:
         state, post_dur, _ = self._apply_ops(state, ops)
 
         if len(ops) > 0:
+            # find an alt, az that is sun-safe for the entire duration of the schedule.
+            # starts with the initial altaz given in the config
             az = self.plan_moves['stow_position']['az_stow']
             alt = self.plan_moves['stow_position']['el_stow']
+
+            # allow for calculation of sun safe stow position to be overidden in config
+            if az is None and alt is None:
+                az = 180
+                alt = 60
+                # add a buffer to start and end to be safe
+                t_start = t0 - dt.timedelta(seconds=300)
+                t_end = t1 + dt.timedelta(seconds=300)
+                az, alt, _, _ = get_parking(t_start, t_end, az, alt, self.plan_moves['sun_policy'], az)
+
+            logger.info(f"found sun safe stow position at ({az}, {alt})")
         else:
             az = all_blocks[-1].az
             alt = all_blocks[-1].alt
@@ -733,30 +770,6 @@ class PlanMoves:
 
         seq = core.seq_sort(seq, flatten=True)
 
-        def get_parking(t0, t1, az0, alt0):
-            # gets a safe parking location for the time range and
-            # Do the move in two steps, parking at az=180 (most likely
-            # to be sun-safe).  Identify a spot that is safe for the
-            # duration of t0 to t1.
-            az_parking = 180.
-            alt_range = alt0, self.sun_policy['min_el']
-            n_alts = max(2, int(round(abs(alt_range[1] - alt_range[0]) / 4. + 1)))
-            for alt_parking in np.linspace(alt_range[0], alt_range[1], n_alts):
-                safet = get_traj_ok_time(az_parking, az_parking, alt_parking, alt_parking,
-                                         t0, self.sun_policy)
-                if safet >= t1:
-                    break
-            else:
-                raise ValueError(f"Sun-safe parking spot not found. az {az_parking} "
-                                 f"el {alt_parking} is safe only until {safet}")
-
-            # Now bracket the moves, hopefully with ~5 minutes on each end.
-            buffer_t = min(300, int((t1 - t0).total_seconds() / 2))
-            t0_parking = t0 + dt.timedelta(seconds=buffer_t)
-            t1_parking = t1 - dt.timedelta(seconds=buffer_t)
-
-            return az_parking, alt_parking, t0_parking, t1_parking
-
         def get_safe_gaps(block0, block1):
             """Returns a list with 0, 1, or 3 Gap blocks.  The Gap blocks will be
             at sunsafe positions for their duration, and be safely
@@ -775,7 +788,8 @@ class PlanMoves:
                            az=block1.az, alt=block1.alt)]
 
             az_parking, alt_parking, t0_parking, t1_parking = get_parking(block0.t1, block1.t0,
-                                                                          block0.az, block0.alt)
+                                                                          block0.az, block0.alt,
+                                                                          self.sun_policy)
 
             def check_parking(t0_parking, t1_parking, alt_parking):
                 if get_traj_ok_time(az_parking, az_parking, alt_parking, alt_parking,
@@ -844,7 +858,8 @@ class PlanMoves:
                     az=block.az, alt=block.alt)])
             else:
                 movet = block.t1 #max(safet, block.t1)
-                az_parking, alt_parking, t0_parking, t1_parking = get_parking(movet, t_end, block.az, block.alt)
+                az_parking, alt_parking, t0_parking, t1_parking = get_parking(movet, t_end, block.az,
+                                                                              block.alt, self.sun_policy)
 
                 get_safe_gaps(block, IR(name='gap', subtype=IRMode.Gap, t0=t0_parking, t1=t1_parking,
                         az=az_parking, alt=alt_parking))


### PR DESCRIPTION
This branch uses the existing sun-safe parking function to try and find a sun-safe home position automatically if the `stow_position` dict is empty or `None`.  It will search at `az=180` and between `el=60` and `el=sun_policy['min_el']` for a stow position.  If `az_stow` and `el_stow` are given in the config, those values are used instead and no calculation is done (in case we want to override it for some reason), though we could eliminate them from the config entirely and only use the calculated ones if we wanted to.