### PR TITLE
Add minimum elevation check for CMB and Calib blocks

### DIFF
--- a/src/schedlib/policies/sat.py
+++ b/src/schedlib/policies/sat.py
@@ -661,11 +661,13 @@ class SATPolicy:
         # -----------------------------------------------------------------
 
         # check if blocks are above min elevation
-        for block in blocks:
-            assert block.alt >= self.rules['sun-avoidance']['min_el'], (
-            f"Block {block} is below the minimum elevation "
-            f"of {self.rules['sun-avoidance']['min_el']} degrees."
-            )
+        for block in core.seq_flatten(blocks):
+            if hasattr(block, 'alt'):
+                assert block.alt >= self.rules['sun-avoidance']['min_el'], (
+                f"Block {block} is below the minimum elevation "
+                f"of {self.rules['sun-avoidance']['min_el']} degrees."
+                )
+
         return blocks
 
     def init_state(self, t0: dt.datetime) -> State:

--- a/src/schedlib/policies/sat.py
+++ b/src/schedlib/policies/sat.py
@@ -656,6 +656,16 @@ class SATPolicy:
 
         blocks = core.seq_sort(blocks['baseline']['cmb'] + blocks['calibration'], flatten=True)
 
+        # -----------------------------------------------------------------
+        # step 5: verify
+        # -----------------------------------------------------------------
+
+        # check if blocks are above min elevation
+        for block in blocks:
+            assert block.alt >= self.rules['sun-avoidance']['min_el'], (
+            f"Block {block} is below the minimum elevation "
+            f"of {self.rules['sun-avoidance']['min_el']} degrees."
+            )
         return blocks
 
     def init_state(self, t0: dt.datetime) -> State:

--- a/src/schedlib/policies/sat.py
+++ b/src/schedlib/policies/sat.py
@@ -669,11 +669,17 @@ class SATPolicy:
         # -----------------------------------------------------------------
 
         # check if blocks are above min elevation
+        alt_limits = self.stages['build_op']['plan_moves']['el_limits']
         for block in core.seq_flatten(blocks):
             if hasattr(block, 'alt'):
-                assert block.alt >= self.rules['sun-avoidance']['min_el'], (
+                assert block.alt >= alt_limits[0], (
                 f"Block {block} is below the minimum elevation "
-                f"of {self.rules['sun-avoidance']['min_el']} degrees."
+                f"of {alt_limits[0]} degrees."
+                )
+
+                assert block.alt < alt_limits[1], (
+                f"Block {block} is above the maximum elevation "
+                f"of {alt_limits[1]} degrees."
                 )
 
         return blocks

--- a/src/schedlib/policies/satp1.py
+++ b/src/schedlib/policies/satp1.py
@@ -250,6 +250,10 @@ def make_config(
         'az_range': [-45, 405]
     }
 
+    el_range = {
+        'el_range': [40, 90]
+    }
+
     config = {
         'blocks': blocks,
         'geometries': geometries,
@@ -278,6 +282,7 @@ def make_config(
                     'sun_policy': sun_policy,
                     'az_step': 0.5,
                     'az_limits': az_range['az_range'],
+                    'el_limits': el_range['el_range'],
                 }
             }
         }

--- a/src/schedlib/policies/satp2.py
+++ b/src/schedlib/policies/satp2.py
@@ -251,6 +251,10 @@ def make_config(
         'az_range': [-45, 405]
     }
 
+    el_range = {
+        'el_range': [40, 90]
+    }
+
     config = {
         'blocks': blocks,
         'geometries': geometries,
@@ -279,6 +283,7 @@ def make_config(
                     'sun_policy': sun_policy,
                     'az_step': 0.5,
                     'az_limits': az_range['az_range'],
+                    'el_limits': el_range['el_range'],
                 }
             }
         }

--- a/src/schedlib/policies/satp3.py
+++ b/src/schedlib/policies/satp3.py
@@ -272,6 +272,10 @@ def make_config(
         'az_range': [-45, 405]
     }
 
+    el_range = {
+        'el_range': [40, 90]
+    }
+
     config = {
         'blocks': blocks,
         'geometries': geometries,
@@ -300,6 +304,7 @@ def make_config(
                     'sun_policy': sun_policy,
                     'az_step': 0.5,
                     'az_limits': az_range['az_range'],
+                    'el_limits': el_range['el_range'],
                 }
             }
         }

--- a/src/schedlib/policies/stages/build_op.py
+++ b/src/schedlib/policies/stages/build_op.py
@@ -764,9 +764,9 @@ class PlanMoves:
     """solve moves to make seq possible"""
     sun_policy: Dict[str, Any]
     stow_position: Dict[str, Any]
+    el_limits: Tuple[float, float]
     az_step: float = 1
     az_limits: Tuple[float, float] = (-90, 450)
-    el_limits: Tuple[float, float] = (40, 90)
 
     def apply(self, seq, t_end):
         """take a list of IR from BuildOp as input to solve for optimal sun-safe moves"""

--- a/src/schedlib/policies/stages/build_op.py
+++ b/src/schedlib/policies/stages/build_op.py
@@ -766,6 +766,7 @@ class PlanMoves:
     stow_position: Dict[str, Any]
     az_step: float = 1
     az_limits: Tuple[float, float] = (-90, 450)
+    el_limits: Tuple[float, float] = (40, 90)
 
     def apply(self, seq, t_end):
         """take a list of IR from BuildOp as input to solve for optimal sun-safe moves"""


### PR DESCRIPTION
Added a check for whether CMB and calibration blocks are above the sun avoidance minimum elevation.  An assert error will be thrown if any blocks are too low.  This is added before gap blocks or moves are calculated, which should all be guaranteed to be above the minimum elevation anyway.  Block division or merging shouldn't affect things either.

Intended to address #107.