### PR TITLE
Fix mutable cal_target list in from_defaults

### DIFF
--- a/src/schedlib/policies/satp1.py
+++ b/src/schedlib/policies/satp1.py
@@ -301,7 +301,7 @@ class SATP1Policy(SATPolicy):
     def from_defaults(cls, master_file, az_speed=0.8, az_accel=1.5,
         iv_cadence=4*u.hour, bias_step_cadence=0.5*u.hour,
         min_hwp_el=48, max_cmb_scan_duration=1*u.hour,
-        cal_targets=[], az_stow=None, el_stow=None,
+        cal_targets=None, az_stow=None, el_stow=None,
         boresight_override=None,  hwp_override=None,
         state_file=None, **op_cfg
     ):

--- a/src/schedlib/policies/satp1.py
+++ b/src/schedlib/policies/satp1.py
@@ -294,9 +294,12 @@ class SATP1Policy(SATPolicy):
     def from_defaults(cls, master_file, az_speed=0.8, az_accel=1.5,
         iv_cadence=4*u.hour, bias_step_cadence=0.5*u.hour,
         min_hwp_el=48, max_cmb_scan_duration=1*u.hour,
-        cal_targets=[], boresight_override=None,
+        cal_targets=None, boresight_override=None,
         state_file=None, **op_cfg
     ):
+        if cal_targets is None:
+            cal_targets = []
+
         x = cls(**make_config(
             master_file, az_speed, az_accel, iv_cadence,
             bias_step_cadence, min_hwp_el, max_cmb_scan_duration,

--- a/src/schedlib/policies/satp2.py
+++ b/src/schedlib/policies/satp2.py
@@ -302,7 +302,7 @@ class SATP2Policy(SATPolicy):
     def from_defaults(cls, master_file, az_speed=0.8, az_accel=1.5,
         iv_cadence=4*u.hour, bias_step_cadence=0.5*u.hour,
         min_hwp_el=48, max_cmb_scan_duration=1*u.hour,
-        cal_targets=[], az_stow=None, el_stow=None,
+        cal_targets=None, az_stow=None, el_stow=None,
         boresight_override=None, hwp_override=None,
         state_file=None, **op_cfg
     ):

--- a/src/schedlib/policies/satp2.py
+++ b/src/schedlib/policies/satp2.py
@@ -295,9 +295,12 @@ class SATP2Policy(SATPolicy):
     def from_defaults(cls, master_file, az_speed=0.8, az_accel=1.5,
         iv_cadence=4*u.hour, bias_step_cadence=0.5*u.hour,
         min_hwp_el=48, max_cmb_scan_duration=1*u.hour,
-        cal_targets=[], boresight_override=None,
+        cal_targets=None, boresight_override=None,
         state_file=None, **op_cfg
     ):
+        if cal_targets is None:
+            cal_targets = []
+
         x = cls(**make_config(
             master_file, az_speed, az_accel,
             iv_cadence, bias_step_cadence, min_hwp_el,

--- a/src/schedlib/policies/satp3.py
+++ b/src/schedlib/policies/satp3.py
@@ -321,7 +321,7 @@ class SATP3Policy(SATPolicy):
     def from_defaults(cls, master_file, az_speed=0.5, az_accel=0.25,
         iv_cadence=4*u.hour, bias_step_cadence=0.5*u.hour,
         min_hwp_el=48, max_cmb_scan_duration=1*u.hour,
-        cal_targets=[], az_stow=None, el_stow=None,
+        cal_targets=None, az_stow=None, el_stow=None,
         boresight_override=None, hwp_override=None,
         state_file=None, **op_cfg
     ):

--- a/src/schedlib/policies/satp3.py
+++ b/src/schedlib/policies/satp3.py
@@ -312,8 +312,11 @@ class SATP3Policy(SATPolicy):
     def from_defaults(cls, master_file, az_speed=0.5, az_accel=0.25,
         iv_cadence=4*u.hour, bias_step_cadence=0.5*u.hour,
         min_hwp_el=48, max_cmb_scan_duration=1*u.hour,
-        cal_targets=[], state_file=None, **op_cfg
+        cal_targets=None, state_file=None, **op_cfg
     ):
+        if cal_targets is None:
+            cal_targets = []
+
         x = cls(**make_config(
             master_file, az_speed, az_accel,
             iv_cadence, bias_step_cadence, min_hwp_el,


### PR DESCRIPTION
Updates the SAT policies `from_defaults` function to address issue #117.  The cal targets remaining even after re-instantiating the policy occurs because the default parameters are only evaluated once when the class/function is defined, so all future calls refer to the same mutable list object.