### PR TITLE
Add tolerance to schedule end time

### DIFF
--- a/src/schedlib/policies/sat.py
+++ b/src/schedlib/policies/sat.py
@@ -489,10 +489,14 @@ class SATPolicy:
         blocks = tu.tree_map(construct_seq, self.blocks,
                              is_leaf=lambda x: isinstance(x, dict) and 'type' in x)
 
-        # if a block ends at at t1 < t <= t1 + t1_tolerance, extend to t1 + tolerance
+        # if a block ends at at t1 < t <= t1 + t1_tolerance, extend t1 to t1 + tolerance
+        t1_new = t1
         for block in blocks['baseline']['cmb']:
             if block.t1 > t1 and (block.t1 - t1).total_seconds() <= self.t1_tolerance:
-                t1 = block.t1
+                t1_new = block.t1
+
+        # update t1
+        t1 = t1_new
 
         # by default add calibration blocks specified in cal_targets if not already specified
         for cal_target in self.cal_targets:
@@ -783,16 +787,16 @@ class SATPolicy:
         # initialize sequences
         seqs = self.init_seqs(t0, t1)
 
-        # check if seqence was extended due to tolerance
-        seq_t1 = core.seq_sort(seq['baseline']['cmb'], flatten=True)[-1].t1
-        if seq_t1 > t1:
-            t1 = seq_t1
-
         # apply observing rules
         seqs = self.apply(seqs)
 
         # initialize state
         state = state or self.init_state(t0)
+
+        # check if seqence was extended due to tolerance
+        seq_t1 = core.seq_sort(seq['baseline']['cmb'], flatten=True)[-1].t1
+        if seq_t1 > t1:
+            t1 = seq_t1
 
         # plan operation seq
         ir = self.seq2cmd(seqs, t0, t1, state)

--- a/src/schedlib/policies/satp1.py
+++ b/src/schedlib/policies/satp1.py
@@ -211,6 +211,7 @@ def make_operations(
 
 def make_config(
     master_file,
+    t1_tolerance,
     az_speed,
     az_accel,
     iv_cadence,
@@ -257,6 +258,7 @@ def make_config(
         },
         'operations': operations,
         'cal_targets': cal_targets,
+        't1_tolerance': t1_tolerance,
         'scan_tag': None,
         'boresight_override': boresight_override,
         'az_speed': az_speed,
@@ -291,14 +293,15 @@ class SATP1Policy(SATPolicy):
     state_file: Optional[str] = None
 
     @classmethod
-    def from_defaults(cls, master_file, az_speed=0.8, az_accel=1.5,
+    def from_defaults(cls, master_file, t1_tolerance=0.0*u.second,
+        az_speed=0.8, az_accel=1.5,
         iv_cadence=4*u.hour, bias_step_cadence=0.5*u.hour,
         min_hwp_el=48, max_cmb_scan_duration=1*u.hour,
         cal_targets=[], boresight_override=None,
         state_file=None, **op_cfg
     ):
         x = cls(**make_config(
-            master_file, az_speed, az_accel, iv_cadence,
+            master_file, t1_tolerance, az_speed, az_accel, iv_cadence,
             bias_step_cadence, min_hwp_el, max_cmb_scan_duration,
             cal_targets, boresight_override, **op_cfg
         ))

--- a/src/schedlib/policies/satp2.py
+++ b/src/schedlib/policies/satp2.py
@@ -212,6 +212,7 @@ def make_operations(
 
 def make_config(
     master_file,
+    t1_tolerance,
     az_speed,
     az_accel,
     iv_cadence,
@@ -258,6 +259,7 @@ def make_config(
         },
         'operations': operations,
         'cal_targets': cal_targets,
+        't1_tolerance': t1_tolerance,
         'scan_tag': None,
         'boresight_override': boresight_override,
         'az_speed' : az_speed,
@@ -292,14 +294,15 @@ class SATP2Policy(SATPolicy):
     state_file: Optional[str] = None
 
     @classmethod
-    def from_defaults(cls, master_file, az_speed=0.8, az_accel=1.5,
+    def from_defaults(cls, master_file, t1_tolerance=0.0*u.second,
+        az_speed=0.8, az_accel=1.5,
         iv_cadence=4*u.hour, bias_step_cadence=0.5*u.hour,
         min_hwp_el=48, max_cmb_scan_duration=1*u.hour,
         cal_targets=[], boresight_override=None,
         state_file=None, **op_cfg
     ):
         x = cls(**make_config(
-            master_file, az_speed, az_accel,
+            master_file, t1_tolerance, az_speed, az_accel,
             iv_cadence, bias_step_cadence, min_hwp_el,
             max_cmb_scan_duration, cal_targets,
             boresight_override, **op_cfg

--- a/src/schedlib/policies/satp3.py
+++ b/src/schedlib/policies/satp3.py
@@ -229,6 +229,7 @@ def make_operations(
 
 def make_config(
     master_file,
+    t1_tolerance,
     az_speed,
     az_accel,
     iv_cadence,
@@ -278,6 +279,7 @@ def make_config(
         },
         'operations': operations,
         'cal_targets': cal_targets,
+        't1_tolerance': t1_tolerance,
         'scan_tag': None,
         'az_speed': az_speed,
         'az_accel': az_accel,
@@ -309,13 +311,14 @@ def make_config(
 @dataclass
 class SATP3Policy(SATPolicy):
     @classmethod
-    def from_defaults(cls, master_file, az_speed=0.5, az_accel=0.25,
+    def from_defaults(cls, master_file, t1_tolerance=0.0*u.second,
+        az_speed=0.5, az_accel=0.25,
         iv_cadence=4*u.hour, bias_step_cadence=0.5*u.hour,
         min_hwp_el=48, max_cmb_scan_duration=1*u.hour,
         cal_targets=[], state_file=None, **op_cfg
     ):
         x = cls(**make_config(
-            master_file, az_speed, az_accel,
+            master_file, t1_tolerance, az_speed, az_accel,
             iv_cadence, bias_step_cadence, min_hwp_el,
             max_cmb_scan_duration,
             cal_targets, **op_cfg)

--- a/src/schedlib/quality_assurance/sun_safety_checker.py
+++ b/src/schedlib/quality_assurance/sun_safety_checker.py
@@ -28,7 +28,7 @@ class SunCrawler:
                 from schedlib.policies.satp3 import make_config
 
         self.configs = make_config(
-            master_file='None',
+            master_file='None', t1_tolerance=None,
             az_speed=None, az_accel=None,
             iv_cadence=None, bias_step_cadence=None,
             min_hwp_el=None, max_cmb_scan_duration=None,


### PR DESCRIPTION
Work in progress.  Intended to address #79.

Adds a tolerance to the end time of the schedule to allow blocks with `t1 < block.t1 <= t1 + tolerance` to finish completely.  The final schedule time t1 is updated to t1 + duration internally.  

To do: Need to find a cleaner way to update t1 between `init_seq` and `apply` in `sat.py.` Need to check if it works well with block division and merging.  Check calib scans.