### PR TITLE
Tentative fix for sun-safety issue

### DIFF
--- a/src/schedlib/policies/stages/build_op.py
+++ b/src/schedlib/policies/stages/build_op.py
@@ -466,7 +466,7 @@ class BuildOp:
         for i in range(1, len(ir_)):
             block0 = ir_[i-1].block
             block1 = ir_[i].block
-
+            # if one block starts immediately after another and they aren't gap blocks
             if ir_[i-1].t1 == ir_[i].t0 and block0 is not None and block1 is not None:
                 safet = get_traj_ok_time(
                     block0.az, block1.az,
@@ -477,14 +477,25 @@ class BuildOp:
                 shift = 10
                 t0 = ir_[i-1].t1
 
+                # is the move sun-safe
                 while safet <= block1.t0:
-                    if ir_[i].subtype == IRMode.PreBlock and i != len(ir_)-1:
+                    # if we are currently in a obs block
+                    if ir_[i].subtype == IRMode.InBlock:
+                    # don't need to update anything else as we will lift the
+                    # obs blocks immediately afterwards
+                        ir_[i] = ir_[i].replace(
+                                block=block1.shrink_left(dt.timedelta(seconds=shift))
+                            )
+                    # if current IR is a pre-obs block we can shrink the next
+                    # observation block
+                    elif ir_[i].subtype == IRMode.PreBlock and i != len(ir_)-1:
                         if ir_[i+1].subtype == IRMode.InBlock:
                             next_block = ir_[i+1].block
                             ir_[i+1] = ir_[i+1].replace(
                                 block=next_block.shrink_left(dt.timedelta(seconds=shift))
                             )
 
+                    # update obs start time
                     t0 += dt.timedelta(seconds=shift)
                     safet = get_traj_ok_time(
                         block0.az, block1.az,

--- a/src/schedlib/policies/stages/build_op.py
+++ b/src/schedlib/policies/stages/build_op.py
@@ -461,7 +461,38 @@ class BuildOp:
 
     def round_trip(self, seq, t0, t1, state, operations):
         ir = self.lower(seq, t0, t1, state, operations)
-        seq = self.lift(ir)
+        ir_ = core.seq_flatten(ir)
+
+        # for i in range(1, len(ir_)):
+        #     block0 = ir_[i-1].block
+        #     block1 = ir_[i].block
+
+        #     if ir_[i-1].t1 == ir_[i].t0 and block0 is not None and block1 is not None:
+        #         safet = get_traj_ok_time(
+        #             block0.az, block1.az,
+        #             block0.alt, block1.alt,
+        #             block0.t1, self.plan_moves['sun_policy']
+        #         )
+
+        #         shift = 10
+        #         t0 = ir_[i-1].t1
+
+        #         while safet <= block1.t0:
+        #             if ir_[i].subtype == IRMode.PreBlock and i != len(ir_)-1:
+        #                 if ir_[i+1].subtype == IRMode.InBlock:
+        #                     next_block = ir_[i+1].block
+        #                     ir_[i+1] = ir_[i+1].replace(
+        #                         block=next_block.shrink_left(dt.timedelta(seconds=shift))
+        #                     )
+
+        #             t0 += dt.timedelta(seconds=shift)
+        #             safet = get_traj_ok_time(
+        #                 block0.az, block1.az,
+        #                 block0.alt, block1.alt,
+        #                 t0, self.plan_moves['sun_policy']
+        #             )
+
+        seq = self.lift(ir_)
 
         # opportunity to do some correction:
         # if our post session is running longer than our constraint, trim the sequence

--- a/src/schedlib/policies/stages/build_op.py
+++ b/src/schedlib/policies/stages/build_op.py
@@ -463,34 +463,34 @@ class BuildOp:
         ir = self.lower(seq, t0, t1, state, operations)
         ir_ = core.seq_flatten(ir)
 
-        # for i in range(1, len(ir_)):
-        #     block0 = ir_[i-1].block
-        #     block1 = ir_[i].block
+        for i in range(1, len(ir_)):
+            block0 = ir_[i-1].block
+            block1 = ir_[i].block
 
-        #     if ir_[i-1].t1 == ir_[i].t0 and block0 is not None and block1 is not None:
-        #         safet = get_traj_ok_time(
-        #             block0.az, block1.az,
-        #             block0.alt, block1.alt,
-        #             block0.t1, self.plan_moves['sun_policy']
-        #         )
+            if ir_[i-1].t1 == ir_[i].t0 and block0 is not None and block1 is not None:
+                safet = get_traj_ok_time(
+                    block0.az, block1.az,
+                    block0.alt, block1.alt,
+                    block0.t1, self.plan_moves['sun_policy']
+                )
 
-        #         shift = 10
-        #         t0 = ir_[i-1].t1
+                shift = 10
+                t0 = ir_[i-1].t1
 
-        #         while safet <= block1.t0:
-        #             if ir_[i].subtype == IRMode.PreBlock and i != len(ir_)-1:
-        #                 if ir_[i+1].subtype == IRMode.InBlock:
-        #                     next_block = ir_[i+1].block
-        #                     ir_[i+1] = ir_[i+1].replace(
-        #                         block=next_block.shrink_left(dt.timedelta(seconds=shift))
-        #                     )
+                while safet <= block1.t0:
+                    if ir_[i].subtype == IRMode.PreBlock and i != len(ir_)-1:
+                        if ir_[i+1].subtype == IRMode.InBlock:
+                            next_block = ir_[i+1].block
+                            ir_[i+1] = ir_[i+1].replace(
+                                block=next_block.shrink_left(dt.timedelta(seconds=shift))
+                            )
 
-        #             t0 += dt.timedelta(seconds=shift)
-        #             safet = get_traj_ok_time(
-        #                 block0.az, block1.az,
-        #                 block0.alt, block1.alt,
-        #                 t0, self.plan_moves['sun_policy']
-        #             )
+                    t0 += dt.timedelta(seconds=shift)
+                    safet = get_traj_ok_time(
+                        block0.az, block1.az,
+                        block0.alt, block1.alt,
+                        t0, self.plan_moves['sun_policy']
+                    )
 
         seq = self.lift(ir_)
 


### PR DESCRIPTION
This branch changes the handling of scans that start immediately after another one, such that there is no gap between them and an unsafe sun move can occur.  It will check if a move between one observation and a pre-obs setup is sun-safe.  If not, it will delay the next obs block until the move becomes sun-safe.  The existing gap-finding code will then find the required moves.

This is a tentative fix meant to address #158 that we may or may not want to integrate, as I don't think this is how we'll probably want to handle this in general, since this change will cut into calibration observation scans (though that may be unavoidable in some cases).