### PR TITLE
update hwp_spin_up/down time and change order of hwp spin up for satp3

### DIFF
--- a/src/schedlib/commands.py
+++ b/src/schedlib/commands.py
@@ -13,7 +13,7 @@ logger = u.init_logger(__name__)
 
 MIN_DURATION = 0.01
 HWP_SPIN_DOWN = 15*u.minute
-HWP_SPIN_UP = 20*u.minute
+HWP_SPIN_UP = 7*u.minute
 
 @dataclass_json
 @dataclass(frozen=True)

--- a/src/schedlib/commands.py
+++ b/src/schedlib/commands.py
@@ -394,18 +394,10 @@ def move_to(state, az, el, min_el=48, force=False):
             "run.hwp.stop(active=True)",
             "sup.disable_driver_board()",
         ]
-    if el == state.el_now:
-        cmd += [f"run.acu.move_to(az={round(az, 3)}, el={(round(el, 3))})"]
-    elif el < state.el_now:
-        cmd += [
-            f"run.acu.move_to(az={round(state.az_now, 3)}, el={round(el, 3)})",
-            f"run.acu.move_to(az={round(az, 3)}, el={round(el, 3)})",
-        ]
-    elif el > state.el_now:
-        cmd += [
-            f"run.acu.move_to(az={round(az, 3)}, el={round(state.el_now, 3)})",
-            f"run.acu.move_to(az={round(az, 3)}, el={round(el, 3)})",
-        ]
+
+    cmd += [
+        f"run.acu.move_to(az={round(az, 3)}, el={round(el, 3)})",
+    ]
     state = state.replace(az_now=az, el_now=el)
 
     return state, duration, cmd

--- a/src/schedlib/commands.py
+++ b/src/schedlib/commands.py
@@ -12,7 +12,7 @@ logger = u.init_logger(__name__)
 
 
 MIN_DURATION = 0.01
-HWP_SPIN_DOWN = 10*u.minute
+HWP_SPIN_DOWN = 15*u.minute
 HWP_SPIN_UP = 20*u.minute
 
 @dataclass_json
@@ -394,10 +394,18 @@ def move_to(state, az, el, min_el=48, force=False):
             "run.hwp.stop(active=True)",
             "sup.disable_driver_board()",
         ]
-
-    cmd += [
-        f"run.acu.move_to(az={round(az, 3)}, el={round(el, 3)})",
-    ]
+    if el == state.el_now:
+        cmd += [f"run.acu.move_to(az={round(az, 3)}, el={(round(el, 3))})"]
+    elif el < state.el_now:
+        cmd += [
+            f"run.acu.move_to(az={round(state.az_now, 3)}, el={round(el, 3)})",
+            f"run.acu.move_to(az={round(az, 3)}, el={round(el, 3)})",
+        ]
+    elif el > state.el_now:
+        cmd += [
+            f"run.acu.move_to(az={round(az, 3)}, el={round(state.el_now, 3)})",
+            f"run.acu.move_to(az={round(az, 3)}, el={round(el, 3)})",
+        ]
     state = state.replace(az_now=az, el_now=el)
 
     return state, duration, cmd

--- a/src/schedlib/policies/sat.py
+++ b/src/schedlib/policies/sat.py
@@ -169,7 +169,7 @@ def hwp_spin_up(state, block, disable_hwp=False):
             "sup.disable_driver_board()",
             ]
         else:
-            return state, 0, [f"# hwp already spinning with forward={state.hwp_dir}"]
+            return state, 0, [f"# hwp already spinning with direction={state.hwp_dir}"]
 
     hwp_dir = block.hwp_dir if block.hwp_dir is not None else state.hwp_dir
     state = state.replace(hwp_dir=hwp_dir)

--- a/src/schedlib/policies/sat.py
+++ b/src/schedlib/policies/sat.py
@@ -379,12 +379,6 @@ def bias_step(state, block, bias_step_cadence=None):
     else:
         return state, 0, []
 
-@cmd.operation(name='sat.wrap_up', duration=0)
-def wrap_up(state):
-    return state, [
-        "time.sleep(1)"
-    ]
-
 @dataclass
 class SATPolicy:
     """a more realistic SAT policy.

--- a/src/schedlib/policies/sat.py
+++ b/src/schedlib/policies/sat.py
@@ -169,7 +169,7 @@ def hwp_spin_up(state, block, disable_hwp=False):
             "sup.disable_driver_board()",
             ]
         else:
-            return state, 0, [f"# hwp already spinning with direction={state.hwp_dir}"]
+            return state, 0, [f"# hwp already spinning with forward={state.hwp_dir}"]
 
     hwp_dir = block.hwp_dir if block.hwp_dir is not None else state.hwp_dir
     state = state.replace(hwp_dir=hwp_dir)

--- a/src/schedlib/policies/satp1.py
+++ b/src/schedlib/policies/satp1.py
@@ -187,22 +187,21 @@ def make_operations(
         ]
     cal_ops = [
         { 'name': 'sat.setup_boresight' , 'sched_mode': SchedMode.PreCal, 'apply_boresight_rot': apply_boresight_rot, },
-        { 'name': 'sat.det_setup'       , 'sched_mode': SchedMode.PreCal, 'apply_boresight_rot': apply_boresight_rot, 'iv_cadence':iv_cadence },
         { 'name': 'sat.hwp_spin_up'     , 'sched_mode': SchedMode.PreCal, 'disable_hwp': disable_hwp},
+        { 'name': 'sat.det_setup'       , 'sched_mode': SchedMode.PreCal, 'apply_boresight_rot': apply_boresight_rot, 'iv_cadence':iv_cadence },
         { 'name': 'sat.source_scan'     , 'sched_mode': SchedMode.InCal, },
         { 'name': 'sat.bias_step'       , 'sched_mode': SchedMode.PostCal, 'bias_step_cadence': bias_step_cadence},
     ]
     cmb_ops = [
         { 'name': 'sat.setup_boresight' , 'sched_mode': SchedMode.PreObs, 'apply_boresight_rot': apply_boresight_rot, },
-        { 'name': 'sat.det_setup'       , 'sched_mode': SchedMode.PreObs, 'apply_boresight_rot': apply_boresight_rot, 'iv_cadence':iv_cadence},
         { 'name': 'sat.hwp_spin_up'     , 'sched_mode': SchedMode.PreObs, 'disable_hwp': disable_hwp},
+        { 'name': 'sat.det_setup'       , 'sched_mode': SchedMode.PreObs, 'apply_boresight_rot': apply_boresight_rot, 'iv_cadence':iv_cadence},
         { 'name': 'sat.bias_step'       , 'sched_mode': SchedMode.PreObs, 'bias_step_cadence': bias_step_cadence},
         { 'name': 'sat.cmb_scan'        , 'sched_mode': SchedMode.InObs, },
     ]
     if home_at_end:
         post_session_ops = [
             { 'name': 'sat.hwp_spin_down'   , 'sched_mode': SchedMode.PostSession, 'disable_hwp': disable_hwp, },
-            { 'name': 'sat.wrap_up'         , 'sched_mode': SchedMode.PostSession},
         ]
     else:
         post_session_ops = []

--- a/src/schedlib/policies/satp1.py
+++ b/src/schedlib/policies/satp1.py
@@ -187,15 +187,15 @@ def make_operations(
         ]
     cal_ops = [
         { 'name': 'sat.setup_boresight' , 'sched_mode': SchedMode.PreCal, 'apply_boresight_rot': apply_boresight_rot, },
-        { 'name': 'sat.hwp_spin_up'     , 'sched_mode': SchedMode.PreCal, 'disable_hwp': disable_hwp},
         { 'name': 'sat.det_setup'       , 'sched_mode': SchedMode.PreCal, 'apply_boresight_rot': apply_boresight_rot, 'iv_cadence':iv_cadence },
+        { 'name': 'sat.hwp_spin_up'     , 'sched_mode': SchedMode.PreCal, 'disable_hwp': disable_hwp},
         { 'name': 'sat.source_scan'     , 'sched_mode': SchedMode.InCal, },
         { 'name': 'sat.bias_step'       , 'sched_mode': SchedMode.PostCal, 'bias_step_cadence': bias_step_cadence},
     ]
     cmb_ops = [
         { 'name': 'sat.setup_boresight' , 'sched_mode': SchedMode.PreObs, 'apply_boresight_rot': apply_boresight_rot, },
-        { 'name': 'sat.hwp_spin_up'     , 'sched_mode': SchedMode.PreObs, 'disable_hwp': disable_hwp},
         { 'name': 'sat.det_setup'       , 'sched_mode': SchedMode.PreObs, 'apply_boresight_rot': apply_boresight_rot, 'iv_cadence':iv_cadence},
+        { 'name': 'sat.hwp_spin_up'     , 'sched_mode': SchedMode.PreObs, 'disable_hwp': disable_hwp},
         { 'name': 'sat.bias_step'       , 'sched_mode': SchedMode.PreObs, 'bias_step_cadence': bias_step_cadence},
         { 'name': 'sat.cmb_scan'        , 'sched_mode': SchedMode.InObs, },
     ]

--- a/src/schedlib/policies/satp2.py
+++ b/src/schedlib/policies/satp2.py
@@ -188,22 +188,21 @@ def make_operations(
         ]
     cal_ops = [
         { 'name': 'sat.setup_boresight' , 'sched_mode': SchedMode.PreCal, 'apply_boresight_rot': apply_boresight_rot, },
-        { 'name': 'sat.det_setup'       , 'sched_mode': SchedMode.PreCal, 'apply_boresight_rot': apply_boresight_rot, 'iv_cadence':iv_cadence },
         { 'name': 'sat.hwp_spin_up'     , 'sched_mode': SchedMode.PreCal, 'disable_hwp': disable_hwp},
+        { 'name': 'sat.det_setup'       , 'sched_mode': SchedMode.PreCal, 'apply_boresight_rot': apply_boresight_rot, 'iv_cadence':iv_cadence },
         { 'name': 'sat.source_scan'     , 'sched_mode': SchedMode.InCal, },
         { 'name': 'sat.bias_step'       , 'sched_mode': SchedMode.PostCal, 'bias_step_cadence': bias_step_cadence},
     ]
     cmb_ops = [
         { 'name': 'sat.setup_boresight' , 'sched_mode': SchedMode.PreObs, 'apply_boresight_rot': apply_boresight_rot, },
-        { 'name': 'sat.det_setup'       , 'sched_mode': SchedMode.PreObs, 'apply_boresight_rot': apply_boresight_rot, 'iv_cadence':iv_cadence},
         { 'name': 'sat.hwp_spin_up'     , 'sched_mode': SchedMode.PreObs, 'disable_hwp': disable_hwp},
+        { 'name': 'sat.det_setup'       , 'sched_mode': SchedMode.PreObs, 'apply_boresight_rot': apply_boresight_rot, 'iv_cadence':iv_cadence},
         { 'name': 'sat.bias_step'       , 'sched_mode': SchedMode.PreObs,  'bias_step_cadence': bias_step_cadence},
         { 'name': 'sat.cmb_scan'        , 'sched_mode': SchedMode.InObs, },
     ]
     if home_at_end:
         post_session_ops = [
             { 'name': 'sat.hwp_spin_down'   , 'sched_mode': SchedMode.PostSession, 'disable_hwp': disable_hwp, },
-            { 'name': 'sat.wrap_up'         , 'sched_mode': SchedMode.PostSession},
         ]
     else:
         post_session_ops = []

--- a/src/schedlib/policies/satp2.py
+++ b/src/schedlib/policies/satp2.py
@@ -188,15 +188,15 @@ def make_operations(
         ]
     cal_ops = [
         { 'name': 'sat.setup_boresight' , 'sched_mode': SchedMode.PreCal, 'apply_boresight_rot': apply_boresight_rot, },
-        { 'name': 'sat.hwp_spin_up'     , 'sched_mode': SchedMode.PreCal, 'disable_hwp': disable_hwp},
         { 'name': 'sat.det_setup'       , 'sched_mode': SchedMode.PreCal, 'apply_boresight_rot': apply_boresight_rot, 'iv_cadence':iv_cadence },
+        { 'name': 'sat.hwp_spin_up'     , 'sched_mode': SchedMode.PreCal, 'disable_hwp': disable_hwp},
         { 'name': 'sat.source_scan'     , 'sched_mode': SchedMode.InCal, },
         { 'name': 'sat.bias_step'       , 'sched_mode': SchedMode.PostCal, 'bias_step_cadence': bias_step_cadence},
     ]
     cmb_ops = [
         { 'name': 'sat.setup_boresight' , 'sched_mode': SchedMode.PreObs, 'apply_boresight_rot': apply_boresight_rot, },
-        { 'name': 'sat.hwp_spin_up'     , 'sched_mode': SchedMode.PreObs, 'disable_hwp': disable_hwp},
         { 'name': 'sat.det_setup'       , 'sched_mode': SchedMode.PreObs, 'apply_boresight_rot': apply_boresight_rot, 'iv_cadence':iv_cadence},
+        { 'name': 'sat.hwp_spin_up'     , 'sched_mode': SchedMode.PreObs, 'disable_hwp': disable_hwp},
         { 'name': 'sat.bias_step'       , 'sched_mode': SchedMode.PreObs,  'bias_step_cadence': bias_step_cadence},
         { 'name': 'sat.cmb_scan'        , 'sched_mode': SchedMode.InObs, },
     ]

--- a/src/schedlib/policies/satp3.py
+++ b/src/schedlib/policies/satp3.py
@@ -206,21 +206,20 @@ def make_operations(
             { 'name': 'sat.ufm_relock'  , 'sched_mode': SchedMode.PreSession, 'commands': commands_uxm_relock, }
         ]
     cal_ops = [
-        { 'name': 'sat.det_setup'       , 'sched_mode': SchedMode.PreCal, 'commands': commands_det_setup, 'apply_boresight_rot': apply_boresight_rot, },
         { 'name': 'sat.hwp_spin_up'     , 'sched_mode': SchedMode.PreCal, 'disable_hwp': disable_hwp},
+        { 'name': 'sat.det_setup'       , 'sched_mode': SchedMode.PreCal, 'commands': commands_det_setup, 'apply_boresight_rot': apply_boresight_rot, },
         { 'name': 'sat.source_scan'     , 'sched_mode': SchedMode.InCal, },
         { 'name': 'sat.bias_step'       , 'sched_mode': SchedMode.PostCal, 'bias_step_cadence': bias_step_cadence},
     ]
     cmb_ops = [
-        { 'name': 'sat.det_setup'       , 'sched_mode': SchedMode.PreObs, 'commands': commands_det_setup, 'apply_boresight_rot': apply_boresight_rot, 'iv_cadence':iv_cadence},
         { 'name': 'sat.hwp_spin_up'     , 'sched_mode': SchedMode.PreObs, 'disable_hwp': disable_hwp},
+        { 'name': 'sat.det_setup'       , 'sched_mode': SchedMode.PreObs, 'commands': commands_det_setup, 'apply_boresight_rot': apply_boresight_rot, 'iv_cadence':iv_cadence},
         { 'name': 'sat.bias_step'       , 'sched_mode': SchedMode.PreObs, 'bias_step_cadence': bias_step_cadence},
         { 'name': 'sat.cmb_scan'        , 'sched_mode': SchedMode.InObs, },
     ]
     if home_at_end:
         post_session_ops = [
             { 'name': 'sat.hwp_spin_down'   , 'sched_mode': SchedMode.PostSession, 'disable_hwp': disable_hwp, },
-            { 'name': 'sat.wrap_up'         , 'sched_mode': SchedMode.PostSession},
         ]
     else:
         post_session_ops = []


### PR DESCRIPTION
1. Changed move_to to move az and el separately. For sun-safety, order of az el motions are different depending on whether el increases or not. This was implemented before https://github.com/simonsobs/scheduler/commit/8a608119036e29163cb0ed8bdc35c30a3ff38cc2
2. Changed order of hwp-spin up and det-setup for consistency. Previously the very first det-setup was performed with hwp stopped, others are performed when hwp is spinning.
3. Deleted wrap_up because it's not necessary. https://simonsobs.slack.com/archives/CJ8M8HY7P/p1712082764375729
4. Change HWP_SPIN_DOWN. This was discussed as scheduler requirement

