### PR TITLE
add az_speed_overwrite

### DIFF
--- a/src/schedlib/policies/sat.py
+++ b/src/schedlib/policies/sat.py
@@ -413,6 +413,7 @@ class SATPolicy:
     scan_tag: Optional[str] = None
     boresight_override: Optional[float] = None
     hwp_override: Optional[bool] = None
+    az_motion_override: bool = False
     az_speed: float = 1. # deg / s
     az_accel: float = 2. # deg / s^2
     iv_cadence : float = 4 * u.hour
@@ -478,6 +479,17 @@ class SATPolicy:
                     blocks = core.seq_map(
                         lambda b: b.replace(
                             hwp_dir=self.hwp_override
+                        ), blocks
+                    )
+                if self.az_motion_override:
+                    blocks = core.seq_map(
+                        lambda b: b.replace(
+                            az_speed=self.az_speed
+                        ), blocks
+                    )
+                    blocks = core.seq_map(
+                        lambda b: b.replace(
+                            az_accel=self.az_accel
                         ), blocks
                     )
                 return blocks

--- a/src/schedlib/policies/satp1.py
+++ b/src/schedlib/policies/satp1.py
@@ -221,6 +221,7 @@ def make_config(
     el_stow=None,
     boresight_override=None,
     hwp_override=None,
+    az_motion_override=False,
     **op_cfg
 ):
     blocks = make_blocks(master_file)
@@ -265,6 +266,7 @@ def make_config(
         'scan_tag': None,
         'boresight_override': boresight_override,
         'hwp_override': hwp_override,
+        'az_motion_override': az_motion_override,
         'az_speed': az_speed,
         'az_accel': az_accel,
         'iv_cadence': iv_cadence,
@@ -302,6 +304,7 @@ class SATP1Policy(SATPolicy):
         min_hwp_el=48, max_cmb_scan_duration=1*u.hour,
         cal_targets=None, az_stow=None, el_stow=None,
         boresight_override=None,  hwp_override=None,
+        az_motion_override=False,
         state_file=None, **op_cfg
     ):
         if cal_targets is None:
@@ -311,7 +314,7 @@ class SATP1Policy(SATPolicy):
             master_file, az_speed, az_accel, iv_cadence,
             bias_step_cadence, min_hwp_el, max_cmb_scan_duration,
             cal_targets, az_stow, el_stow, boresight_override,
-            hwp_override, **op_cfg
+            hwp_override, az_motion_override, **op_cfg
         ))
         x.state_file=state_file
         return x

--- a/src/schedlib/policies/satp2.py
+++ b/src/schedlib/policies/satp2.py
@@ -222,6 +222,7 @@ def make_config(
     el_stow=None,
     boresight_override=None,
     hwp_override=None,
+    az_motion_override=False,
     **op_cfg
 ):
     blocks = make_blocks(master_file)
@@ -266,6 +267,7 @@ def make_config(
         'scan_tag': None,
         'boresight_override': boresight_override,
         'hwp_override':  hwp_override,
+        'az_motion_override': az_motion_override,
         'az_speed' : az_speed,
         'az_accel' : az_accel,
         'iv_cadence' : iv_cadence,
@@ -303,6 +305,7 @@ class SATP2Policy(SATPolicy):
         min_hwp_el=48, max_cmb_scan_duration=1*u.hour,
         cal_targets=None, az_stow=None, el_stow=None,
         boresight_override=None, hwp_override=None,
+        az_motion_override=False,
         state_file=None, **op_cfg
     ):
         if cal_targets is None:
@@ -313,7 +316,7 @@ class SATP2Policy(SATPolicy):
             iv_cadence, bias_step_cadence, min_hwp_el,
             max_cmb_scan_duration, cal_targets,
             az_stow, el_stow, boresight_override,
-            hwp_override, **op_cfg
+            hwp_override,az_motion_override, **op_cfg
         ))
         x.state_file=state_file
         return x

--- a/src/schedlib/policies/satp3.py
+++ b/src/schedlib/policies/satp3.py
@@ -239,6 +239,7 @@ def make_config(
     el_stow=None,
     boresight_override=None,
     hwp_override=None,
+    az_motion_override=False,
     **op_cfg
 ):
     blocks = make_blocks(master_file)
@@ -287,6 +288,7 @@ def make_config(
         'scan_tag': None,
         'boresight_override': boresight_override,
         'hwp_override': hwp_override,
+        'az_motion_override': az_motion_override,
         'az_speed': az_speed,
         'az_accel': az_accel,
         'iv_cadence': iv_cadence,
@@ -322,6 +324,7 @@ class SATP3Policy(SATPolicy):
         min_hwp_el=48, max_cmb_scan_duration=1*u.hour,
         cal_targets=None, az_stow=None, el_stow=None,
         boresight_override=None, hwp_override=None,
+        az_motion_override=False,
         state_file=None, **op_cfg
     ):
         if cal_targets is None:
@@ -332,7 +335,7 @@ class SATP3Policy(SATPolicy):
             iv_cadence, bias_step_cadence, min_hwp_el,
             max_cmb_scan_duration, cal_targets,
             az_stow, el_stow, boresight_override,
-            hwp_override, **op_cfg)
+            hwp_override, az_motion_override, **op_cfg)
         )
         x.state_file = state_file
         return x


### PR DESCRIPTION
To fix https://github.com/simonsobs/scheduler/issues/164.
Add new parameter `az_speed_overwrite`, which can handle `az_speed` and `az_accel` either master file or from run.yaml file in scheduler-scripts.
I will make PR in scheduler-scripts as well.