### PR TITLE
Add state file loading to base sat policy/satp3 policy

### DIFF
--- a/src/schedlib/policies/sat.py
+++ b/src/schedlib/policies/sat.py
@@ -499,6 +499,8 @@ class SATPolicy:
 
     Parameters
     ----------
+    state_file : str
+        a string that provides the path to the state file
     blocks : dict
         a dict of blocks, with keys 'baseline' and 'calibration'
     rules : dict
@@ -520,6 +522,7 @@ class SATPolicy:
     operations : List[Dict[str, Any]]
         an orderred list of operation configurations
     """
+    state_file: Optional[str] = None
     blocks: Dict[str, Any] = field(default_factory=dict)
     rules: Dict[str, core.Rule] = field(default_factory=dict)
     geometries: List[Dict[str, Any]] = field(default_factory=list)
@@ -884,11 +887,22 @@ class SATPolicy:
         -------
         State
         """
+        if self.state_file is not None:
+            logger.info(f"using state from {self.state_file}")
+            state = State.load(self.state_file)
+            if state.curr_time < t0:
+                logger.info(
+                    f"Loaded state is at {state.curr_time}. Updating time to"
+                    f" {t0}"
+                )
+                state = state.replace(curr_time = t0)
+            return state
+
         return State(
             curr_time=t0,
             az_now=180,
             el_now=48,
-            boresight_rot_now=0,
+            boresight_rot_now=None,
             hwp_spinning=False,
         )
 

--- a/src/schedlib/policies/satp1.py
+++ b/src/schedlib/policies/satp1.py
@@ -212,6 +212,7 @@ def make_operations(
 
 def make_config(
     master_file,
+    state_file,
     az_speed,
     az_accel,
     iv_cadence,
@@ -258,6 +259,7 @@ def make_config(
     }
 
     config = {
+        'state_file': state_file,
         'blocks': blocks,
         'geometries': geometries,
         'rules': {
@@ -303,27 +305,23 @@ def make_config(
 
 @dataclass
 class SATP1Policy(SATPolicy):
-    state_file: Optional[str] = None
-
     @classmethod
-    def from_defaults(cls, master_file, az_speed=0.8, az_accel=1.5,
+    def from_defaults(cls, master_file, state_file=None, az_speed=0.8, az_accel=1.5,
         iv_cadence=4*u.hour, bias_step_cadence=0.5*u.hour,
         min_hwp_el=48, max_cmb_scan_duration=1*u.hour,
         cal_targets=None, az_stow=None, el_stow=None,
         boresight_override=None,  hwp_override=None,
-        az_motion_override=False,
-        state_file=None, **op_cfg
+        az_motion_override=False, **op_cfg
     ):
         if cal_targets is None:
             cal_targets = []
 
         x = cls(**make_config(
-            master_file, az_speed, az_accel, iv_cadence,
+            master_file, state_file, az_speed, az_accel, iv_cadence,
             bias_step_cadence, min_hwp_el, max_cmb_scan_duration,
             cal_targets, az_stow, el_stow, boresight_override,
             hwp_override, az_motion_override, **op_cfg
         ))
-        x.state_file=state_file
         return x
 
     def add_cal_target(self, *args, **kwargs):

--- a/src/schedlib/policies/satp2.py
+++ b/src/schedlib/policies/satp2.py
@@ -210,6 +210,7 @@ def make_operations(
 
 def make_config(
     master_file,
+    state_file,
     az_speed,
     az_accel,
     iv_cadence,
@@ -256,6 +257,7 @@ def make_config(
     }
 
     config = {
+        'state_file': state_file,
         'blocks': blocks,
         'geometries': geometries,
         'rules': {
@@ -301,35 +303,31 @@ def make_config(
 
 @dataclass
 class SATP2Policy(SATPolicy):
-    state_file: Optional[str] = None
-
     @classmethod
-    def from_defaults(cls, master_file, az_speed=0.8, az_accel=1.5,
+    def from_defaults(cls, master_file, state_file=None, az_speed=0.8, az_accel=1.5,
         iv_cadence=4*u.hour, bias_step_cadence=0.5*u.hour,
         min_hwp_el=48, max_cmb_scan_duration=1*u.hour,
         cal_targets=None, az_stow=None, el_stow=None,
         boresight_override=None, hwp_override=None,
-        az_motion_override=False,
-        state_file=None, **op_cfg
+        az_motion_override=False, **op_cfg
     ):
         if cal_targets is None:
             cal_targets = []
 
         x = cls(**make_config(
-            master_file, az_speed, az_accel,
+            master_file, state_file, az_speed, az_accel,
             iv_cadence, bias_step_cadence, min_hwp_el,
             max_cmb_scan_duration, cal_targets,
             az_stow, el_stow, boresight_override,
             hwp_override, az_motion_override, **op_cfg
         ))
-        x.state_file=state_file
         return x
 
     def add_cal_target(self, *args, **kwargs):
         self.cal_targets.append(make_cal_target(*args, **kwargs))
 
     def init_state(self, t0: dt.datetime) -> State:
-        """customize typical initial state for satp1, if needed"""
+        """customize typical initial state for satp2, if needed"""
         if self.state_file is not None:
             logger.info(f"using state from {self.state_file}")
             state = State.load(self.state_file)

--- a/src/schedlib/policies/satp3.py
+++ b/src/schedlib/policies/satp3.py
@@ -230,6 +230,7 @@ def make_operations(
 
 def make_config(
     master_file,
+    state_file,
     az_speed,
     az_accel,
     iv_cadence,
@@ -280,6 +281,7 @@ def make_config(
     }
 
     config = {
+        'state_file': state_file,
         'blocks': blocks,
         'geometries': geometries,
         'rules': {
@@ -326,19 +328,18 @@ def make_config(
 @dataclass
 class SATP3Policy(SATPolicy):
     @classmethod
-    def from_defaults(cls, master_file, az_speed=0.5, az_accel=0.25,
+    def from_defaults(cls, master_file, state_file=None, az_speed=0.5, az_accel=0.25,
         iv_cadence=4*u.hour, bias_step_cadence=0.5*u.hour,
         min_hwp_el=48, max_cmb_scan_duration=1*u.hour,
         cal_targets=None, az_stow=None, el_stow=None,
         boresight_override=None, hwp_override=None,
-        az_motion_override=False,
-        state_file=None, **op_cfg
+        az_motion_override=False, **op_cfg
     ):
         if cal_targets is None:
             cal_targets = []
 
         x = cls(**make_config(
-            master_file, az_speed, az_accel,
+            master_file, state_file, az_speed, az_accel,
             iv_cadence, bias_step_cadence, min_hwp_el,
             max_cmb_scan_duration, cal_targets,
             az_stow, el_stow, boresight_override,
@@ -351,7 +352,18 @@ class SATP3Policy(SATPolicy):
         self.cal_targets.append(make_cal_target(*args, **kwargs))
 
     def init_state(self, t0: dt.datetime) -> State:
-        """customize typical initial state for satp1, if needed"""
+        """customize typical initial state for satp3, if needed"""
+        if self.state_file is not None:
+            logger.info(f"using state from {self.state_file}")
+            state = State.load(self.state_file)
+            if state.curr_time < t0:
+                logger.info(
+                    f"Loaded state is at {state.curr_time}. Updating time to"
+                    f" {t0}"
+                )
+                state = state.replace(curr_time = t0)
+            return state
+
         return State(
             curr_time=t0,
             az_now=180,

--- a/src/schedlib/quality_assurance/sun_safety_checker.py
+++ b/src/schedlib/quality_assurance/sun_safety_checker.py
@@ -29,12 +29,13 @@ class SunCrawler:
 
         self.configs = make_config(
             master_file='None',
+            state_file=None,
             az_speed=None, az_accel=None,
             iv_cadence=None, bias_step_cadence=None,
             min_hwp_el=None, max_cmb_scan_duration=None,
             cal_targets=None,
         )['rules']['sun-avoidance']
-            
+
         if not path is None:
             self.from_cmds = False
             self.cmd_n = 0


### PR DESCRIPTION
This updates the `init_state` functions in the base SATPolicy and to the SATP3 policy in order to add state file loading which was only implemented in the inherited state loading functions of SATP1 and SATP2.  I left the init_state functions in the per-sat policies just in case we still want to override the base one at some point in the future.  There is a matching scheduler-scripts branch for this branch.