### PR TITLE
Add socs for scheduler-server

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -14,6 +14,7 @@ setup(
         "jax[cpu]",
         "equinox",
         "so3g",
+        "socs",
         "pixell",
         "dataclasses_json",
     ],


### PR DESCRIPTION
The `scheduler-server` needs `scheduler` to have `socs` imported due to its use in `quality_assurance` by `scheduler-scripts/sat/gen_schedule.py.`