### PR TITLE
Updates for scheduler-server

### DIFF
--- a/src/schedlib/policies/sat.py
+++ b/src/schedlib/policies/sat.py
@@ -987,6 +987,10 @@ class SATPolicy:
                 raise ValueError(f"unexpected block subtype: {block.subtype}")
 
         seq = [map_block(b) for b in seq]
+
+        # check if any observations were added
+        assert len(seq) != 0, "No observations fall within time-range"
+
         start_block = {
             'name': 'pre-session',
             'block': inst.StareBlock(name="pre-session", az=state.az_now, alt=state.el_now, t0=t0, t1=t0+dt.timedelta(seconds=1)),

--- a/src/schedlib/policies/stages/build_op.py
+++ b/src/schedlib/policies/stages/build_op.py
@@ -1410,7 +1410,7 @@ class PlanMoves:
                     az=block.az, alt=block.alt)])
             else:
                 movet = block.t1 #max(safet, block.t1)
-                buffer_t = dt.timedelta(seconds=300)
+                buffer_t = dt.timedelta(seconds=min(300, int((t_end - movet).total_seconds() / 2)))
                 az_parking, alt_parking, t0_parking, t1_parking = get_parking(movet, t_end + buffer_t, block.alt, self.sun_policy)
 
                 move_away_by = get_traj_ok_time(

--- a/src/schedlib/policies/stages/build_op.py
+++ b/src/schedlib/policies/stages/build_op.py
@@ -1410,7 +1410,8 @@ class PlanMoves:
                     az=block.az, alt=block.alt)])
             else:
                 movet = block.t1 #max(safet, block.t1)
-                az_parking, alt_parking, t0_parking, t1_parking = get_parking(movet, t_end, block.alt, self.sun_policy)
+                buffer_t = dt.timedelta(seconds=300)
+                az_parking, alt_parking, t0_parking, t1_parking = get_parking(movet, t_end + buffer_t, block.alt, self.sun_policy)
 
                 move_away_by = get_traj_ok_time(
                     block.az, az_parking, block.alt, alt_parking, movet, self.sun_policy)


### PR DESCRIPTION
Changes the stow command at the end to ensure the final wait command ends at `t1`.  Previously, it would end some buffer time (usually 5 minutes) before, which will likely lead to an error when the server tries to generate a schedule that is only the length of that buffer.

Also adds an assert if the number of cmb and cal observations is greater than zero to provide a more informative error message for `nextline`.