### PR TITLE
Always set state current time to t0

### DIFF
--- a/src/schedlib/policies/lat.py
+++ b/src/schedlib/policies/lat.py
@@ -614,7 +614,7 @@ class LATPolicy(tel.TelPolicy):
         if self.state_file is not None:
             logger.info(f"using state from {self.state_file}")
             state = State.load(self.state_file)
-            if state.curr_time < t0:
+            if state.curr_time != t0:
                 logger.info(
                     f"Loaded state is at {state.curr_time}. Updating time to"
                     f" {t0}"

--- a/src/schedlib/policies/sat.py
+++ b/src/schedlib/policies/sat.py
@@ -634,7 +634,7 @@ class SATPolicy(tel.TelPolicy):
         if self.state_file is not None:
             logger.info(f"using state from {self.state_file}")
             state = State.load(self.state_file)
-            if state.curr_time < t0:
+            if state.curr_time != t0:
                 logger.info(
                     f"Loaded state is at {state.curr_time}. Updating time to"
                     f" {t0}"

--- a/src/schedlib/policies/satp1.py
+++ b/src/schedlib/policies/satp1.py
@@ -292,7 +292,7 @@ class SATP1Policy(SATPolicy):
         if self.state_file is not None:
             logger.info(f"using state from {self.state_file}")
             state = State.load(self.state_file)
-            if state.curr_time < t0:
+            if state.curr_time != t0:
                 logger.info(
                     f"Loaded state is at {state.curr_time}. Updating time to"
                     f" {t0}"

--- a/src/schedlib/policies/satp2.py
+++ b/src/schedlib/policies/satp2.py
@@ -288,7 +288,7 @@ class SATP2Policy(SATPolicy):
         if self.state_file is not None:
             logger.info(f"using state from {self.state_file}")
             state = State.load(self.state_file)
-            if state.curr_time < t0:
+            if state.curr_time != t0:
                 logger.info(
                     f"Loaded state is at {state.curr_time}. Updating time to"
                     f" {t0}"

--- a/src/schedlib/policies/satp3.py
+++ b/src/schedlib/policies/satp3.py
@@ -302,7 +302,7 @@ class SATP3Policy(SATPolicy):
         if self.state_file is not None:
             logger.info(f"using state from {self.state_file}")
             state = State.load(self.state_file)
-            if state.curr_time < t0:
+            if state.curr_time != t0:
                 logger.info(
                     f"Loaded state is at {state.curr_time}. Updating time to"
                     f" {t0}"


### PR DESCRIPTION
This is mostly to make #170 work with the `scheduler-server`.  Since it takes time for the server to determine the state of the system, the current time (determined in `get_sat_state`) will be after `t0`.  This just sets the current time of an input state file to `t0` regardless of whether the state current time was larger or smaller than `t0`.  I don't think we have any reason to allow loading in future states.

An alternative would be to set the current state to `t0` in `gen_schedule` after `get_sat_state` is called and before it is saved to a state file.