### PR TITLE
Update lat az_range and el_range

### DIFF
--- a/src/schedlib/policies/lat.py
+++ b/src/schedlib/policies/lat.py
@@ -295,7 +295,7 @@ def make_config(
     }
 
     el_range = {
-        'el_range': [0, 90]
+        'el_range': [0, 175]
     }
 
     config = {

--- a/src/schedlib/policies/lat.py
+++ b/src/schedlib/policies/lat.py
@@ -291,11 +291,11 @@ def make_config(
 
     az_range = {
         'trim': False,
-        'az_range': [-45, 405]
+        'az_range': [-175, 355]
     }
 
     el_range = {
-        'el_range': [40, 90]
+        'el_range': [0, 90]
     }
 
     config = {


### PR DESCRIPTION
Intended to address #183.  Change az_range to [-175, 355] to match specifications in https://simonsobs.atlassian.net/wiki/spaces/PRO/pages/165380132/LAT+Encoder+Coordinates with 5-degree allowance.  Also change el_range to [0, 90] since I don't think we need to accommodate <0 or >90 in the scheduler.

I think all the angle wrapping in `build_ops` and `rules` should be fine with the change, but will keep checking.