### PR TITLE
Add acu_stop_and_clear

### DIFF
--- a/src/schedlib/policies/lat.py
+++ b/src/schedlib/policies/lat.py
@@ -85,6 +85,10 @@ class SchedMode(tel.SchedMode):
 def preamble():
     return tel.preamble()
 
+@cmd.operation(name='lat.wrap_up', duration=0)
+def wrap_up(state, block):
+    return tel.wrap_up(state, block)
+
 @cmd.operation(name='lat.ufm_relock', return_duration=True)
 def ufm_relock(state, commands=None, relock_cadence=24*u.hour):
     return tel.ufm_relock(state, commands, relock_cadence)
@@ -265,6 +269,10 @@ def make_operations(
         { 'name': 'lat.det_setup'       , 'sched_mode': SchedMode.PreObs, 'apply_boresight_rot': False, 'iv_cadence':iv_cadence},
         { 'name': 'lat.bias_step'       , 'sched_mode': SchedMode.PreObs, 'bias_step_cadence': bias_step_cadence},
         { 'name': 'lat.cmb_scan'        , 'sched_mode': SchedMode.InObs, },
+    ]
+
+    post_session_ops = [
+        { 'name': 'lat.wrap_up'   , 'sched_mode': SchedMode.PostSession},
     ]
 
     return pre_session_ops + cal_ops + cmb_ops

--- a/src/schedlib/policies/sat.py
+++ b/src/schedlib/policies/sat.py
@@ -173,6 +173,10 @@ def preamble():
     append = ["sup = OCSClient('hwp-supervisor')", "",]
     return base + append
 
+@cmd.operation(name='sat.wrap_up', duration=0)
+def wrap_up(state, block):
+    return tel.wrap_up(state, block)
+
 @cmd.operation(name='sat.ufm_relock', return_duration=True)
 def ufm_relock(state, commands=None, relock_cadence=24*u.hour):
     return tel.ufm_relock(state, commands, relock_cadence)

--- a/src/schedlib/policies/satp1.py
+++ b/src/schedlib/policies/satp1.py
@@ -177,15 +177,14 @@ def make_operations(
         { 'name': 'sat.bias_step'       , 'sched_mode': SchedMode.PreObs, 'bias_step_cadence': bias_step_cadence},
         { 'name': 'sat.cmb_scan'        , 'sched_mode': SchedMode.InObs, },
     ]
+    post_session_ops = []
     if home_at_end:
-        post_session_ops = [
+        post_session_ops += [
             { 'name': 'sat.hwp_spin_down'   , 'sched_mode': SchedMode.PostSession, 'disable_hwp': disable_hwp, },
-            { 'name': 'sat.wrap_up'   , 'sched_mode': SchedMode.PostSession},
         ]
-    else:
-        post_session_ops = [
-            { 'name': 'sat.wrap_up'   , 'sched_mode': SchedMode.PostSession},
-        ]
+    post_session_ops += [
+        { 'name': 'sat.wrap_up'   , 'sched_mode': SchedMode.PostSession},
+    ]
 
     wiregrid_ops = [
         { 'name': 'sat.wiregrid', 'sched_mode': SchedMode.Wiregrid }

--- a/src/schedlib/policies/satp1.py
+++ b/src/schedlib/policies/satp1.py
@@ -180,9 +180,12 @@ def make_operations(
     if home_at_end:
         post_session_ops = [
             { 'name': 'sat.hwp_spin_down'   , 'sched_mode': SchedMode.PostSession, 'disable_hwp': disable_hwp, },
+            { 'name': 'sat.wrap_up'   , 'sched_mode': SchedMode.PostSession},
         ]
     else:
-        post_session_ops = []
+        post_session_ops = [
+            { 'name': 'sat.wrap_up'   , 'sched_mode': SchedMode.PostSession},
+        ]
 
     wiregrid_ops = [
         { 'name': 'sat.wiregrid', 'sched_mode': SchedMode.Wiregrid }

--- a/src/schedlib/policies/satp2.py
+++ b/src/schedlib/policies/satp2.py
@@ -180,9 +180,12 @@ def make_operations(
     if home_at_end:
         post_session_ops = [
             { 'name': 'sat.hwp_spin_down'   , 'sched_mode': SchedMode.PostSession, 'disable_hwp': disable_hwp, },
+            { 'name': 'sat.wrap_up'   , 'sched_mode': SchedMode.PostSession},
         ]
     else:
-        post_session_ops = []
+        post_session_ops = [
+            { 'name': 'sat.wrap_up'   , 'sched_mode': SchedMode.PostSession},
+        ]
 
     return pre_session_ops + cal_ops + cmb_ops + post_session_ops
 

--- a/src/schedlib/policies/satp2.py
+++ b/src/schedlib/policies/satp2.py
@@ -177,15 +177,14 @@ def make_operations(
         { 'name': 'sat.bias_step'       , 'sched_mode': SchedMode.PreObs,  'bias_step_cadence': bias_step_cadence},
         { 'name': 'sat.cmb_scan'        , 'sched_mode': SchedMode.InObs, },
     ]
+    post_session_ops = []
     if home_at_end:
-        post_session_ops = [
+        post_session_ops += [
             { 'name': 'sat.hwp_spin_down'   , 'sched_mode': SchedMode.PostSession, 'disable_hwp': disable_hwp, },
-            { 'name': 'sat.wrap_up'   , 'sched_mode': SchedMode.PostSession},
         ]
-    else:
-        post_session_ops = [
-            { 'name': 'sat.wrap_up'   , 'sched_mode': SchedMode.PostSession},
-        ]
+    post_session_ops += [
+        { 'name': 'sat.wrap_up'   , 'sched_mode': SchedMode.PostSession},
+    ]
 
     return pre_session_ops + cal_ops + cmb_ops + post_session_ops
 

--- a/src/schedlib/policies/satp3.py
+++ b/src/schedlib/policies/satp3.py
@@ -187,9 +187,12 @@ def make_operations(
     if home_at_end:
         post_session_ops = [
             { 'name': 'sat.hwp_spin_down'   , 'sched_mode': SchedMode.PostSession, 'disable_hwp': disable_hwp, },
+            { 'name': 'sat.wrap_up'   , 'sched_mode': SchedMode.PostSession},
         ]
     else:
-        post_session_ops = []
+        post_session_ops = [
+            { 'name': 'sat.wrap_up'   , 'sched_mode': SchedMode.PostSession},
+        ]
 
     wiregrid_ops = [
         { 'name': 'sat.wiregrid', 'sched_mode': SchedMode.Wiregrid }

--- a/src/schedlib/policies/satp3.py
+++ b/src/schedlib/policies/satp3.py
@@ -184,15 +184,14 @@ def make_operations(
         { 'name': 'sat.bias_step'       , 'sched_mode': SchedMode.PreObs, 'bias_step_cadence': bias_step_cadence},
         { 'name': 'sat.cmb_scan'        , 'sched_mode': SchedMode.InObs, },
     ]
+    post_session_ops = []
     if home_at_end:
-        post_session_ops = [
+        post_session_ops += [
             { 'name': 'sat.hwp_spin_down'   , 'sched_mode': SchedMode.PostSession, 'disable_hwp': disable_hwp, },
-            { 'name': 'sat.wrap_up'   , 'sched_mode': SchedMode.PostSession},
         ]
-    else:
-        post_session_ops = [
-            { 'name': 'sat.wrap_up'   , 'sched_mode': SchedMode.PostSession},
-        ]
+    post_session_ops += [
+        { 'name': 'sat.wrap_up'   , 'sched_mode': SchedMode.PostSession},
+    ]
 
     wiregrid_ops = [
         { 'name': 'sat.wiregrid', 'sched_mode': SchedMode.Wiregrid }

--- a/src/schedlib/policies/stages/build_op.py
+++ b/src/schedlib/policies/stages/build_op.py
@@ -651,7 +651,7 @@ class BuildOpSimple:
                 state, _, op_blocks = self._apply_ops(state, op_cfgs, az=ir.az, alt=ir.alt)
             elif ir.subtype in [IRMode.PreBlock, IRMode.InBlock, IRMode.PostBlock]:
                 if ir.block.name in ['pre-session', 'post-session']:
-                    state, _, op_blocks = self._apply_ops(state, ir.operations, az=ir.az, alt=ir.alt)
+                    state, _, op_blocks = self._apply_ops(state, ir.operations, az=ir.az, alt=ir.alt, block=ir.block)
                 else:
                     op_cfgs = [{'name': 'wait_until', 'sched_mode': IRMode.Aux, 't1': ir.t0}]
                     state, _, op_blocks_wait = self._apply_ops(state, op_cfgs, az=ir.az, alt=ir.alt)

--- a/src/schedlib/policies/tel.py
+++ b/src/schedlib/policies/tel.py
@@ -159,6 +159,12 @@ def preamble():
         "",
         ]
 
+def wrap_up(state, block):
+    return state, [
+         f"run.wait_until('{block.t1.isoformat()}')",
+        "run.acu.stop_and_clear()"
+    ]
+
 def ufm_relock(state, commands=None, relock_cadence=24*u.hour):
     doit = False
     if state.last_ufm_relock is None:


### PR DESCRIPTION
Reintroduces the `wrap_up` command to add `run.acu.stop_and_clear()` at the end to ensure the telescope is stopped when the next schedule is started.

This has revealed a bug that occurs when a CMB observation leads right up to the end of the schedule, which will result in the post-session being cut despite being higher priority.  Will be fixed in a later PR.