### PR TITLE
Add hwp braking option

### DIFF
--- a/src/schedlib/policies/sat.py
+++ b/src/schedlib/policies/sat.py
@@ -27,6 +27,15 @@ HWP_SPIN_DOWN = 15*u.minute
 BORESIGHT_DURATION = 1*u.minute
 WIREGRID_DURATION = 15*u.minute
 
+COMMANDS_HWP_BRAKE = [
+    "run.hwp.stop(active=True)",
+    "sup.disable_driver_board()",
+]
+COMMANDS_HWP_STOP = [
+    "sup.hwp_stop(active=False)",
+    "sup.disable_driver_board()",
+]
+
 @dataclass_json
 @dataclass(frozen=True)
 class State(tel.State):
@@ -189,7 +198,7 @@ def ufm_relock(state, commands=None, relock_cadence=24*u.hour):
     return tel.ufm_relock(state, commands, relock_cadence)
 
 @cmd.operation(name='sat.hwp_spin_up', return_duration=True)
-def hwp_spin_up(state, block, disable_hwp=False):
+def hwp_spin_up(state, block, disable_hwp=False, brake_hwp=True):
     cmds = []
     duration = 0
 
@@ -200,10 +209,7 @@ def hwp_spin_up(state, block, disable_hwp=False):
         # if spinning in opposite direction, spin down first
         if block.hwp_dir is not None and state.hwp_dir != block.hwp_dir:
             duration += HWP_SPIN_DOWN
-            cmds += [
-            "run.hwp.stop(active=True)",
-            "sup.disable_driver_board()",
-            ]
+            cmds += COMMANDS_HWP_BRAKE if brake_hwp else COMMANDS_HWP_STOP
         else:
             return state, 0, [f"# hwp already spinning with forward={state.hwp_dir}"]
 
@@ -218,17 +224,15 @@ def hwp_spin_up(state, block, disable_hwp=False):
     ]
 
 @cmd.operation(name='sat.hwp_spin_down', return_duration=True)
-def hwp_spin_down(state, disable_hwp=False):
+def hwp_spin_down(state, disable_hwp=False, brake_hwp=True):
     if disable_hwp:
         return state, 0, ["# hwp disabled"]
     elif not state.hwp_spinning:
         return state, 0, ["# hwp already stopped"]
     else:
         state = state.replace(hwp_spinning=False)
-        return state, HWP_SPIN_DOWN, [
-            "run.hwp.stop(active=True)",
-            "sup.disable_driver_board()",
-        ]
+        cmd = COMMANDS_HWP_BRAKE if brake_hwp else COMMANDS_HWP_STOP
+        return state, HWP_SPIN_DOWN, cmd
 
 # per block operation: block will be passed in as parameter
 @cmd.operation(name='sat.det_setup', return_duration=True)
@@ -244,7 +248,7 @@ def source_scan(state, block):
     return tel.source_scan(state, block)
 
 @cmd.operation(name='sat.setup_boresight', return_duration=True)
-def setup_boresight(state, block, apply_boresight_rot=True):
+def setup_boresight(state, block, apply_boresight_rot=True, brake_hwp=True):
     commands = []
     duration = 0
 
@@ -254,11 +258,7 @@ def setup_boresight(state, block, apply_boresight_rot=True):
         if state.hwp_spinning:
             state = state.replace(hwp_spinning=False)
             duration += HWP_SPIN_DOWN
-            commands += [
-                "run.hwp.stop(active=True)",
-                "sup.disable_driver_board()",
-            ]
-
+            commands += COMMANDS_HWP_BRAKE if brake_hwp else COMMANDS_HWP_STOP
         assert not state.hwp_spinning
         commands += [f"run.acu.set_boresight({block.boresight_angle})"]
         state = state.replace(boresight_rot_now=block.boresight_angle)
@@ -278,7 +278,7 @@ def wiregrid(state):
     ]
 
 @cmd.operation(name="move_to", return_duration=True)
-def move_to(state, az, el, min_el=48, force=False):
+def move_to(state, az, el, min_el=48, brake_hwp=True, force=False):
     if not force and (state.az_now == az and state.el_now == el):
         return state, 0, []
 
@@ -288,11 +288,7 @@ def move_to(state, az, el, min_el=48, force=False):
     if state.hwp_spinning and el < min_el:
         state = state.replace(hwp_spinning=False)
         duration += HWP_SPIN_DOWN
-        cmd += [
-            "run.hwp.stop(active=True)",
-            "sup.disable_driver_board()",
-        ]
-
+        cmd += COMMANDS_HWP_BRAKE if brake_hwp else COMMANDS_HWP_STOP
     cmd += [
         f"run.acu.move_to(az={round(az, 3)}, el={round(el, 3)})",
     ]
@@ -313,6 +309,7 @@ class SATPolicy(tel.TelPolicy):
         the minimum elevation a move command to go to without stopping the hwp first
     """
     hwp_override: Optional[bool] = None
+    brake_hwp: Optional[bool] = True
     min_hwp_el: float = 48 # deg
     boresight_override: Optional[float] = None
  

--- a/src/schedlib/policies/sat.py
+++ b/src/schedlib/policies/sat.py
@@ -32,7 +32,7 @@ COMMANDS_HWP_BRAKE = [
     "sup.disable_driver_board()",
 ]
 COMMANDS_HWP_STOP = [
-    "sup.hwp_stop(active=False)",
+    "run.hwp_stop(active=False)",
     "sup.disable_driver_board()",
 ]
 

--- a/src/schedlib/policies/sat.py
+++ b/src/schedlib/policies/sat.py
@@ -305,8 +305,12 @@ class SATPolicy(tel.TelPolicy):
     hwp_override : bool
         a bool that specifies the hwp direction if overriding the master schedule.  True is forward
         and False is reverse.
+    'brake_hwp : bool
+        a bool that specifies whether or not active braking should be used for the hwp.
     min_hwp_el : float
         the minimum elevation a move command to go to without stopping the hwp first
+    'boresight_override : float
+        the angle of boresight to use if not None
     """
     hwp_override: Optional[bool] = None
     brake_hwp: Optional[bool] = True

--- a/src/schedlib/policies/sat.py
+++ b/src/schedlib/policies/sat.py
@@ -305,11 +305,11 @@ class SATPolicy(tel.TelPolicy):
     hwp_override : bool
         a bool that specifies the hwp direction if overriding the master schedule.  True is forward
         and False is reverse.
-    'brake_hwp : bool
+    brake_hwp : bool
         a bool that specifies whether or not active braking should be used for the hwp.
     min_hwp_el : float
         the minimum elevation a move command to go to without stopping the hwp first
-    'boresight_override : float
+    boresight_override : float
         the angle of boresight to use if not None
     """
     hwp_override: Optional[bool] = None

--- a/src/schedlib/policies/satp1.py
+++ b/src/schedlib/policies/satp1.py
@@ -133,6 +133,7 @@ def make_operations(
     iv_cadence=4*u.hour,
     bias_step_cadence=0.5*u.hour,
     det_setup_duration=20*u.minute,
+    brake_hwp=True,
     disable_hwp=False,
     apply_boresight_rot=True,
     hwp_cfg=None,
@@ -162,25 +163,25 @@ def make_operations(
         ]
 
     cal_ops += [
-        { 'name': 'sat.setup_boresight' , 'sched_mode': SchedMode.PreCal, 'apply_boresight_rot': apply_boresight_rot, },
+        { 'name': 'sat.setup_boresight' , 'sched_mode': SchedMode.PreCal, 'apply_boresight_rot': apply_boresight_rot, 'brake_hwp': brake_hwp},
         { 'name': 'sat.det_setup'       , 'sched_mode': SchedMode.PreCal, 'apply_boresight_rot': apply_boresight_rot, 'iv_cadence':iv_cadence,
         'det_setup_duration': det_setup_duration},
-        { 'name': 'sat.hwp_spin_up'     , 'sched_mode': SchedMode.PreCal, 'disable_hwp': disable_hwp,},
+        { 'name': 'sat.hwp_spin_up'     , 'sched_mode': SchedMode.PreCal, 'disable_hwp': disable_hwp, 'brake_hwp': brake_hwp},
         { 'name': 'sat.source_scan'     , 'sched_mode': SchedMode.InCal, },
         { 'name': 'sat.bias_step'       , 'sched_mode': SchedMode.PostCal, 'bias_step_cadence': bias_step_cadence},
     ]
     cmb_ops += [
-        { 'name': 'sat.setup_boresight' , 'sched_mode': SchedMode.PreObs, 'apply_boresight_rot': apply_boresight_rot, },
+        { 'name': 'sat.setup_boresight' , 'sched_mode': SchedMode.PreObs, 'apply_boresight_rot': apply_boresight_rot, 'brake_hwp': brake_hwp},
         { 'name': 'sat.det_setup'       , 'sched_mode': SchedMode.PreObs, 'apply_boresight_rot': apply_boresight_rot, 'iv_cadence':iv_cadence,
         'det_setup_duration': det_setup_duration},
-        { 'name': 'sat.hwp_spin_up'     , 'sched_mode': SchedMode.PreObs, 'disable_hwp': disable_hwp,},
+        { 'name': 'sat.hwp_spin_up'     , 'sched_mode': SchedMode.PreObs, 'disable_hwp': disable_hwp, 'brake_hwp': brake_hwp},
         { 'name': 'sat.bias_step'       , 'sched_mode': SchedMode.PreObs, 'bias_step_cadence': bias_step_cadence},
         { 'name': 'sat.cmb_scan'        , 'sched_mode': SchedMode.InObs, },
     ]
     post_session_ops = []
     if home_at_end:
         post_session_ops += [
-            { 'name': 'sat.hwp_spin_down'   , 'sched_mode': SchedMode.PostSession, 'disable_hwp': disable_hwp, },
+            { 'name': 'sat.hwp_spin_down'   , 'sched_mode': SchedMode.PostSession, 'disable_hwp': disable_hwp, 'brake_hwp': brake_hwp},
         ]
     post_session_ops += [
         { 'name': 'sat.wrap_up'   , 'sched_mode': SchedMode.PostSession},
@@ -205,6 +206,7 @@ def make_config(
     el_stow=None,
     boresight_override=None,
     hwp_override=None,
+    brake_hwp=True,
     az_motion_override=False,
     **op_cfg
 ):
@@ -217,6 +219,7 @@ def make_config(
         az_speed, az_accel,
         iv_cadence, bias_step_cadence,
         det_setup_duration,
+        brake_hwp,
         **op_cfg
     )
 
@@ -259,6 +262,7 @@ def make_config(
         'scan_tag': None,
         'boresight_override': boresight_override,
         'hwp_override': hwp_override,
+        'brake_hwp': brake_hwp,
         'az_motion_override': az_motion_override,
         'az_speed': az_speed,
         'az_accel': az_accel,
@@ -305,6 +309,7 @@ class SATP1Policy(SATPolicy):
         el_stow=None,
         boresight_override=None,
         hwp_override=None,
+        brake_hwp=True,
         az_motion_override=False,
         **op_cfg
     ):
@@ -324,6 +329,7 @@ class SATP1Policy(SATPolicy):
             el_stow,
             boresight_override,
             hwp_override,
+            brake_hwp,
             az_motion_override,
             **op_cfg
         ))

--- a/src/schedlib/policies/satp2.py
+++ b/src/schedlib/policies/satp2.py
@@ -133,6 +133,7 @@ def make_operations(
     iv_cadence=4*u.hour,
     bias_step_cadence=0.5*u.hour,
     det_setup_duration=20*u.minute,
+    brake_hwp=True,
     disable_hwp=False,
     apply_boresight_rot=True,
     hwp_cfg=None,
@@ -162,25 +163,25 @@ def make_operations(
         ]
 
     cal_ops += [
-        { 'name': 'sat.setup_boresight' , 'sched_mode': SchedMode.PreCal, 'apply_boresight_rot': apply_boresight_rot, },
+        { 'name': 'sat.setup_boresight' , 'sched_mode': SchedMode.PreCal, 'apply_boresight_rot': apply_boresight_rot, 'brake_hwp': brake_hwp},
         { 'name': 'sat.det_setup'       , 'sched_mode': SchedMode.PreCal, 'apply_boresight_rot': apply_boresight_rot, 'iv_cadence':iv_cadence,
         'det_setup_duration': det_setup_duration},
-        { 'name': 'sat.hwp_spin_up'     , 'sched_mode': SchedMode.PreCal, 'disable_hwp': disable_hwp,},
+        { 'name': 'sat.hwp_spin_up'     , 'sched_mode': SchedMode.PreCal, 'disable_hwp': disable_hwp, 'brake_hwp': brake_hwp},
         { 'name': 'sat.source_scan'     , 'sched_mode': SchedMode.InCal, },
         { 'name': 'sat.bias_step'       , 'sched_mode': SchedMode.PostCal, 'bias_step_cadence': bias_step_cadence},
     ]
     cmb_ops += [
-        { 'name': 'sat.setup_boresight' , 'sched_mode': SchedMode.PreObs, 'apply_boresight_rot': apply_boresight_rot, },
+        { 'name': 'sat.setup_boresight' , 'sched_mode': SchedMode.PreObs, 'apply_boresight_rot': apply_boresight_rot, 'brake_hwp': brake_hwp},
         { 'name': 'sat.det_setup'       , 'sched_mode': SchedMode.PreObs, 'apply_boresight_rot': apply_boresight_rot, 'iv_cadence':iv_cadence,
         'det_setup_duration': det_setup_duration},
-        { 'name': 'sat.hwp_spin_up'     , 'sched_mode': SchedMode.PreObs, 'disable_hwp': disable_hwp,},
+        { 'name': 'sat.hwp_spin_up'     , 'sched_mode': SchedMode.PreObs, 'disable_hwp': disable_hwp, 'brake_hwp': brake_hwp},
         { 'name': 'sat.bias_step'       , 'sched_mode': SchedMode.PreObs,  'bias_step_cadence': bias_step_cadence},
         { 'name': 'sat.cmb_scan'        , 'sched_mode': SchedMode.InObs, },
     ]
     post_session_ops = []
     if home_at_end:
         post_session_ops += [
-            { 'name': 'sat.hwp_spin_down'   , 'sched_mode': SchedMode.PostSession, 'disable_hwp': disable_hwp, },
+            { 'name': 'sat.hwp_spin_down'   , 'sched_mode': SchedMode.PostSession, 'disable_hwp': disable_hwp, 'brake_hwp': brake_hwp},
         ]
     post_session_ops += [
         { 'name': 'sat.wrap_up'   , 'sched_mode': SchedMode.PostSession},
@@ -202,6 +203,7 @@ def make_config(
     el_stow=None,
     boresight_override=None,
     hwp_override=None,
+    brake_hwp=True,
     az_motion_override=False,
     **op_cfg
 ):
@@ -214,6 +216,7 @@ def make_config(
         az_speed, az_accel,
         iv_cadence, bias_step_cadence,
         det_setup_duration,
+        brake_hwp,
         **op_cfg
     )
 
@@ -256,6 +259,7 @@ def make_config(
         'scan_tag': None,
         'boresight_override': boresight_override,
         'hwp_override':  hwp_override,
+        'brake_hwp': brake_hwp,
         'az_motion_override': az_motion_override,
         'az_speed' : az_speed,
         'az_accel' : az_accel,
@@ -302,6 +306,7 @@ class SATP2Policy(SATPolicy):
         el_stow=None,
         boresight_override=None,
         hwp_override=None,
+        brake_hwp=True,
         az_motion_override=False,
         **op_cfg
     ):
@@ -322,6 +327,7 @@ class SATP2Policy(SATPolicy):
             el_stow,
             boresight_override,
             hwp_override,
+            brake_hwp,
             az_motion_override,
             **op_cfg
         ))

--- a/src/schedlib/policies/satp3.py
+++ b/src/schedlib/policies/satp3.py
@@ -141,6 +141,7 @@ def make_operations(
     iv_cadence=4*u.hour,
     bias_step_cadence=0.5*u.hour,
     det_setup_duration=20*u.minute,
+    brake_hwp=True,
     disable_hwp=False,
     apply_boresight_rot=False,
     hwp_cfg=None,
@@ -171,14 +172,14 @@ def make_operations(
         ]
 
     cal_ops += [
-        { 'name': 'sat.hwp_spin_up'     , 'sched_mode': SchedMode.PreCal, 'disable_hwp': disable_hwp,},
+        { 'name': 'sat.hwp_spin_up'     , 'sched_mode': SchedMode.PreCal, 'disable_hwp': disable_hwp, 'brake_hwp': brake_hwp},
         { 'name': 'sat.det_setup'       , 'sched_mode': SchedMode.PreCal, 'commands': commands_det_setup, 'apply_boresight_rot': apply_boresight_rot,
         'det_setup_duration': det_setup_duration},
         { 'name': 'sat.source_scan'     , 'sched_mode': SchedMode.InCal, },
         { 'name': 'sat.bias_step'       , 'sched_mode': SchedMode.PostCal, 'bias_step_cadence': bias_step_cadence},
     ]
     cmb_ops += [
-        { 'name': 'sat.hwp_spin_up'     , 'sched_mode': SchedMode.PreObs, 'disable_hwp': disable_hwp,},
+        { 'name': 'sat.hwp_spin_up'     , 'sched_mode': SchedMode.PreObs, 'disable_hwp': disable_hwp, 'brake_hwp': brake_hwp},
         { 'name': 'sat.det_setup'       , 'sched_mode': SchedMode.PreObs, 'commands': commands_det_setup, 'apply_boresight_rot': apply_boresight_rot, 'iv_cadence':iv_cadence,
         'det_setup_duration': det_setup_duration},
         { 'name': 'sat.bias_step'       , 'sched_mode': SchedMode.PreObs, 'bias_step_cadence': bias_step_cadence},
@@ -187,7 +188,7 @@ def make_operations(
     post_session_ops = []
     if home_at_end:
         post_session_ops += [
-            { 'name': 'sat.hwp_spin_down'   , 'sched_mode': SchedMode.PostSession, 'disable_hwp': disable_hwp, },
+            { 'name': 'sat.hwp_spin_down'   , 'sched_mode': SchedMode.PostSession, 'disable_hwp': disable_hwp, 'brake_hwp': brake_hwp},
         ]
     post_session_ops += [
         { 'name': 'sat.wrap_up'   , 'sched_mode': SchedMode.PostSession},
@@ -212,6 +213,7 @@ def make_config(
     el_stow=None,
     boresight_override=None,
     hwp_override=None,
+    brake_hwp=True,
     az_motion_override=False,
     **op_cfg
 ):
@@ -224,6 +226,7 @@ def make_config(
         az_speed, az_accel,
         iv_cadence, bias_step_cadence,
         det_setup_duration,
+        brake_hwp,
         **op_cfg
     )
 
@@ -270,6 +273,7 @@ def make_config(
         'scan_tag': None,
         'boresight_override': boresight_override,
         'hwp_override': hwp_override,
+        'brake_hwp': brake_hwp,
         'az_motion_override': az_motion_override,
         'az_speed': az_speed,
         'az_accel': az_accel,
@@ -316,6 +320,7 @@ class SATP3Policy(SATPolicy):
         el_stow=None,
         boresight_override=None,
         hwp_override=None,
+        brake_hwp=True,
         az_motion_override=False,
         **op_cfg
     ):
@@ -335,6 +340,7 @@ class SATP3Policy(SATPolicy):
             el_stow,
             boresight_override,
             hwp_override,
+            brake_hwp,
             az_motion_override,
             **op_cfg)
         )

--- a/src/schedlib/policies/stages/build_op.py
+++ b/src/schedlib/policies/stages/build_op.py
@@ -648,6 +648,8 @@ class BuildOpSimple:
                 # add min hwp elevation if present
                 if hasattr(self.policy_config, 'min_hwp_el'):
                     op_cfgs[0]['min_el'] = self.policy_config.min_hwp_el
+                if hasattr(self.policy_config, 'brake_hwp'):
+                    op_cfgs[0]['brake_hwp'] = self.policy_config.brake_hwp
                 state, _, op_blocks = self._apply_ops(state, op_cfgs, az=ir.az, alt=ir.alt)
             elif ir.subtype in [IRMode.PreBlock, IRMode.InBlock, IRMode.PostBlock]:
                 if ir.block.name in ['pre-session', 'post-session']:


### PR DESCRIPTION
Adds a `brake_hwp` command to the `SAT` policies and relevant commands, which decides if `active` should be `True` or not.