### PR TITLE
Cal Block HWP direction handling

### DIFF
--- a/src/schedlib/policies/sat.py
+++ b/src/schedlib/policies/sat.py
@@ -624,7 +624,7 @@ class SATPolicy(tel.TelPolicy):
         # add hwp direction to cal blocks
         if self.hwp_override is None:
             for i, block in enumerate(blocks):
-                if block.subtype=='cal':
+                if block.subtype=='cal' and block.hwp_dir is not None:
                     # try next blocks
                     for j in range(1, len(blocks)-i):
                         if blocks[i+j].subtype=="cmb":

--- a/src/schedlib/policies/sat.py
+++ b/src/schedlib/policies/sat.py
@@ -569,7 +569,6 @@ class SATPolicy(tel.TelPolicy):
             )
 
             # override hwp direction
-            print('hwp_override: ', self.hwp_override)
             if self.hwp_override is not None:
                 cal_block = cal_block.replace(
                     hwp_dir=self.hwp_override

--- a/src/schedlib/policies/sat.py
+++ b/src/schedlib/policies/sat.py
@@ -625,21 +625,17 @@ class SATPolicy(tel.TelPolicy):
         if self.hwp_override is None:
             for i, block in enumerate(blocks):
                 if block.subtype=='cal':
-                    j = 1
                     # try next blocks
-                    while i + j < len(blocks):
-                        if (blocks[i+j].subtype=="cmb"):
+                    for j in range(1, len(blocks)-i):
+                        if blocks[i+j].subtype=="cmb":
                             blocks[i] = block.replace(hwp_dir=blocks[i+j].hwp_dir)
                             break
-                        j = j + 1
                     else:
-                        j = 1
                         # try previous blocks
-                        while i - j >= 0:
-                            if (blocks[i-j].subtype=="cmb"):
+                        for j in range(1, i+1):
+                            if blocks[i-j].subtype=="cmb":
                                 blocks[i] = block.replace(hwp_dir=blocks[i-j].hwp_dir)
                                 break
-                            j = j + 1
                         else:
                             raise ValueError(f"Cannot assign HWP direction to cal block {block}")
 


### PR DESCRIPTION
Addresses #171.  Cal blocks now take HWP direction from nearby CMB blocks.  Starts by trying to find a CMB block that occur after, but then searches previously if no later occurring CMB blocks were found.  Raises a `ValueError` if it cannot find any CMB blocks to copy from unless `hwp_override` is `True`.  Also, added `hwp_override` to cal blocks.  This can be used when running `no_cmb=True.`