### PR TITLE
Sun-safety Adjustment

### DIFF
--- a/src/schedlib/policies/stages/build_op.py
+++ b/src/schedlib/policies/stages/build_op.py
@@ -291,8 +291,6 @@ class BuildOpSimple:
 
             seq_out = []
             for i, b in enumerate(seq):
-                # if i < len(seq) - 1:
-                #     print(seq[i+1]['block'])
                 # if it's already an planned, just execute it, otherwise plan it
                 # if isinstance(b, list) and all(isinstance(x, IR) for x in b):
                 #     for x in b:
@@ -505,14 +503,18 @@ class BuildOpSimple:
         shift = 10
         if prev_block is None:
             safet = get_traj_ok_time(block.az, block.az, block.alt, block.alt, state.curr_time, self.plan_moves['sun_policy'])
+        elif prev_block.t1 == block.t0:
+            safet = get_traj_ok_time(prev_block.az, block.az, prev_block.alt, block.alt, state.curr_time, self.plan_moves['sun_policy'])
         else:
             az_parking, alt_parking, t0_parking, t1_parking = get_parking(prev_block.t1, block.t0,
                                                                           prev_block.alt, self.plan_moves['sun_policy'])
             safet = get_traj_ok_time(az_parking, block.az, alt_parking, block.alt, state.curr_time, self.plan_moves['sun_policy'])
-        while safet <= state.curr_time:
+        while safet < block.t0:
             state = state.replace(curr_time=state.curr_time + dt.timedelta(seconds=shift))
             if prev_block is None:
                 safet = get_traj_ok_time(block.az, block.az, block.alt, block.alt, state.curr_time, self.plan_moves['sun_policy'])
+            elif prev_block.t1 == block.t0:
+                safet = get_traj_ok_time(prev_block.az, block.az, prev_block.alt, block.alt, state.curr_time, self.plan_moves['sun_policy'])
             else:
                 safet = get_traj_ok_time(az_parking, block.az, alt_parking, block.alt, state.curr_time, self.plan_moves['sun_policy'])
 

--- a/src/schedlib/policies/stages/build_op.py
+++ b/src/schedlib/policies/stages/build_op.py
@@ -506,13 +506,15 @@ class BuildOpSimple:
         if prev_block is None:
             safet = get_traj_ok_time(block.az, block.az, block.alt, block.alt, state.curr_time, self.plan_moves['sun_policy'])
         else:
-            safet = get_traj_ok_time(prev_block.az, block.az, prev_block.alt, block.alt, state.curr_time, self.plan_moves['sun_policy'])
+            az_parking, alt_parking, t0_parking, t1_parking = get_parking(prev_block.t1, block.t0,
+                                                                          prev_block.alt, self.plan_moves['sun_policy'])
+            safet = get_traj_ok_time(az_parking, block.az, alt_parking, block.alt, state.curr_time, self.plan_moves['sun_policy'])
         while safet <= state.curr_time:
             state = state.replace(curr_time=state.curr_time + dt.timedelta(seconds=shift))
             if prev_block is None:
                 safet = get_traj_ok_time(block.az, block.az, block.alt, block.alt, state.curr_time, self.plan_moves['sun_policy'])
             else:
-                safet = get_traj_ok_time(prev_block.az, block.az, prev_block.alt, block.alt, state.curr_time, self.plan_moves['sun_policy'])
+                safet = get_traj_ok_time(az_parking, block.az, alt_parking, block.alt, state.curr_time, self.plan_moves['sun_policy'])
 
         initial_state = state
 

--- a/src/schedlib/quality_assurance/sun_safety_checker.py
+++ b/src/schedlib/quality_assurance/sun_safety_checker.py
@@ -16,9 +16,9 @@ class SunCrawler:
     def __init__(self, platform, path=None, cmd_txt=None):
         assert platform in ['satp1', 'satp2', 'satp3', 'lat'], (
             f"{platform} is not an implemented platform, choose from satp1, "
-             "satp2, or satp3"
+             "satp2, satp3, or lat"
         )
-    
+
         match platform:
             case "satp1":
                 from schedlib.policies.satp1 import make_config


### PR DESCRIPTION
Changes the way blocks are planned such that it delays the the start of the current block to occur only when the move from the previous block to the current one is sun-safe.  I think this should fix the sun-safety error occurring due to detector operations occurring too early, but will not solve #196 or #158.  This is an imperfect fix because it really would need to find and check a move to and from a gap position, but the gap location is not known yet at this point in the code.  Still double checking things, but the main change for the failed schedule on 03/14 is:

Failed:
```
run.wait_until('2025-03-14T19:10:00+00:00')
run.acu.move_to(az=180, el=60.0)
run.wait_until('2025-03-14T19:22:28.069222+00:00')
run.acu.move_to(az=9.804, el=48.0)
run.wait_until('2025-03-14T19:22:28.069222+00:00')
```

New:
```
run.wait_until('2025-03-14T19:10:00+00:00')
run.acu.move_to(az=180, el=60.0)
run.wait_until('2025-03-14T19:48:11.040000+00:00')
run.acu.move_to(az=1.752, el=48.0)
run.wait_until('2025-03-14T19:48:11.040000+00:00')
```
