### PR TITLE
Add data streaming during HWP spin up and HWP spin down

### DIFF
--- a/src/schedlib/policies/sat.py
+++ b/src/schedlib/policies/sat.py
@@ -28,12 +28,18 @@ BORESIGHT_DURATION = 1*u.minute
 WIREGRID_DURATION = 15*u.minute
 
 COMMANDS_HWP_BRAKE = [
+    "run.smurf.stream('on', subtype='cal', tag='hwp_spin_down')",
     "run.hwp.stop(active=True)",
     "sup.disable_driver_board()",
+    "run.smurf.stream('off')",
+    "",
 ]
 COMMANDS_HWP_STOP = [
+    "run.smurf.stream('on', subtype='cal', tag='hwp_spin_down')",
     "run.hwp.stop(active=False)",
     "sup.disable_driver_board()",
+    "run.smurf.stream('off')",
+    "",
 ]
 
 @dataclass_json
@@ -221,8 +227,11 @@ def hwp_spin_up(state, block, disable_hwp=False, brake_hwp=True):
 
     freq = 2 if hwp_dir else -2
     return state, duration + HWP_SPIN_UP, cmds + [
+        "run.smurf.stream('on', subtype='cal', tag='hwp_spin_up')",
         "sup.enable_driver_board()",
         f"run.hwp.set_freq(freq={freq})",
+        "run.smurf.stream('off')",
+        "",
     ]
 
 @cmd.operation(name='sat.hwp_spin_down', return_duration=True)


### PR DESCRIPTION
This is based on some discussions about needing to get more data on detector time constants. This streams data every time we spin the HWP up or down. We should be able to use this data to watch the HWPSS change and calculating the detector time constants. 