### PR TITLE
20250418 more corotate

### DIFF
--- a/src/schedlib/policies/sat.py
+++ b/src/schedlib/policies/sat.py
@@ -326,6 +326,13 @@ class SATPolicy(tel.TelPolicy):
                     boresight_angle=self.boresight_override
                 ), blocks
             )
+        # override hwp direction
+        if self.hwp_override is not None:
+            blocks = core.seq_map(
+                lambda b: b.replace(
+                    hwp_dir=self.hwp_override
+                ), blocks
+            )
         return super().apply_overrides(blocks)
 
     @classmethod
@@ -406,14 +413,6 @@ class SATPolicy(tel.TelPolicy):
             self.blocks,
             is_leaf=lambda x: isinstance(x, dict) and 'type' in x
         )
-
-        # override hwp direction
-        if self.hwp_override is not None:
-            blocks['baseline'] = core.seq_map(
-                lambda b: b.replace(
-                    hwp_dir=self.hwp_override
-                ), blocks['baseline']
-            )
 
         # by default add calibration blocks specified in cal_targets if not already specified
         for cal_target in self.cal_targets:


### PR DESCRIPTION
Ok, I made a few changes to how we're doing this to make the implementation more equal to the SATs, etc. 

From an instrument perspective we have two different ways we might want to run the co-rotator, with "Locked to elevation axis" where we set the corotator to maintain boresight = 0. Or we explicitly set the corotator position. 

* Added some comments to the acu commands because I dislike that that will be the ONLY place where boresight=co-rotator
* `apply_corotator_rotation` turns off all corotator commands. This matches with `apply_boresight_rotation` for the SATs. 
* `corotator_override` affects the CMB blocks just like `boresight_override` does. 
    * also moved the SAT `hwp_override` to the same place in the block generation for consistency
* `make_cal_targets` for the LAT assumes we're running in a locked configuration unless corotator is specified for the cal target

The code for cal targets is a little circular but I think it's the best setup for "all scheduler math works in boresight"

1. `make_cal_targets` works out the boresight requested for the scan
2. All of the source_scan math is done in boresight until the exact `cal_block` to run is chosen
3. The `cal_block` has it's corotator angle set correctly so this can be used for command planning


One thought: it also totally makes sense for the SATs to also have a cryo stabilization time for boresight rotations