### PR TITLE
Fix elevations under 90 work around

### DIFF
--- a/src/schedlib/policies/lat.py
+++ b/src/schedlib/policies/lat.py
@@ -420,11 +420,21 @@ class LATPolicy(tel.TelPolicy):
     def apply_overrides(self, blocks):
 
         if self.elevations_under_90:
+            """
+            as of 20250419, reference plans indication boresight180 scans
+            ONLY by listing the elevation as 180-el on sky. 
+            """
             def fix_block(b):
                 if b.alt > 90:
-                    return b.replace(alt=180-b.alt, az=b.az-180)
+                    return b.replace(alt=180-b.alt)
                 return b
             blocks = core.seq_map( fix_block, blocks)
+        else:
+            raise NotImplementedError(
+                "scheduler not implemented for boresight180 scans yet"
+                " schedules must be generated with elevations_under_90"
+                " set to True"
+            )
 
         if len(self.remove_targets) > 0:
             blocks = core.seq_filter_out(


### PR DESCRIPTION
The reference plan does not change azimuth ranges when using elevation > 90. Which is another way of saying the reference plan doesn't reflect what we'd actually need to command to the telescope to get the "boresight=180 scans." This fixes it for the current reference plan but will need updates when we get that fixed. 