### PR TITLE
Add tolerance to scan pre-blocks wait commands

### DIFF
--- a/src/schedlib/commands.py
+++ b/src/schedlib/commands.py
@@ -331,10 +331,15 @@ def make_op(name, *args, **kwargs):
 
 # common operations
 @operation(name='wait_until', return_duration=True)
-def wait_until(state, t1: dt.datetime):
-    return state, max((t1-state.curr_time).total_seconds(), 0), [
-        f"run.wait_until('{t1.isoformat(timespec='seconds')}')"
-    ]
+def wait_until(state, t1: dt.datetime, tolerance: dt.timedelta=dt.timedelta(0*u.second)):
+    if tolerance.total_seconds() > 0:
+        return state, max((t1-state.curr_time).total_seconds(), 0), [
+            f"run.wait_until('{t1.isoformat(timespec='seconds')}', tolerance={tolerance.total_seconds()})"
+        ]
+    else:
+        return state, max((t1-state.curr_time).total_seconds(), 0), [
+            f"run.wait_until('{t1.isoformat(timespec='seconds')}')"
+        ]
 
 @operation(name='start_time')
 def start_time(state):

--- a/src/schedlib/policies/stages/build_op.py
+++ b/src/schedlib/policies/stages/build_op.py
@@ -801,13 +801,16 @@ class BuildOpSimple:
                 if ir.block.name in ['pre-session', 'post-session']:
                     state, _, op_blocks = self._apply_ops(state, ir.operations, az=ir.az, alt=ir.alt, block=ir.block)
                 else:
+                    tolerance=dt.timedelta(seconds=0)
                     if ir.subtype == IRMode.PreBlock:
                         wait_time = ir.t0
+                        # add a tolerance for wait commands during scan pre-blocks
+                        tolerance=dt.timedelta(seconds=1200)
                     elif ir.subtype == IRMode.InBlock:
                         wait_time = ir.block.t0
                     else:
                          wait_time = ir.block.t1
-                    op_cfgs = [{'name': 'wait_until', 'sched_mode': IRMode.Aux, 't1': wait_time}]
+                    op_cfgs = [{'name': 'wait_until', 'sched_mode': IRMode.Aux, 't1': wait_time, 'tolerance': tolerance}]
                     state, _, op_blocks_wait = self._apply_ops(state, op_cfgs, az=ir.az, alt=ir.alt)
                     state, _, op_blocks_cmd = self._apply_ops(state, ir.operations, block=ir.block)
                     op_blocks = op_blocks_wait + op_blocks_cmd


### PR DESCRIPTION
Adds a tolerance of 20 minutes to the wait commands that occur before pre-block operations of all scans (CMB, calibration, and wiregrid) to make sure that commands that were supposed to be run more than 20 mins in the past are not included.  This will still add a tolerance even if the pre-block operations aren't run (i.e. hwp already spinning) because of how the blocks work, but this shouldn't be a problem I think.  Does not add a tolerance to other wait commands.