### PR TITLE
Change hwp direction terminology to avoid confusion

### DIFF
--- a/src/schedlib/instrument.py
+++ b/src/schedlib/instrument.py
@@ -34,7 +34,9 @@ class ScanBlock(core.NamedBlock):
     corotator_angle : float, optional
         Corotator angle in degrees (default is None)
     hwp_dir : bool, optional
-        HWP direction for SATs. Forward is True, backwards if False.
+        HWP direction for SATs. Counter-clockwise seen from sky
+        (positive frequency) is True, clockwise seen from sky
+        (negative frequency) is False.
         Default is None.
     subtype : str, optional
         Subtype of the scan block (default is an empty string).

--- a/src/schedlib/policies/sat.py
+++ b/src/schedlib/policies/sat.py
@@ -58,7 +58,9 @@ class State(tel.State):
     hwp_spinning : bool
         Whether the high-precision measurement wheel is spinning or not.
     hwp_dir : bool
-        Current direction of HWP.  True is forward, False is backwards.
+        Current direction of HWP. True is Counter-clockwise seen from sky
+        (positive frequency), False is clock wise seen from sky (negative
+        frequency).
     """
     boresight_rot_now: float = 0
     hwp_spinning: bool = False
@@ -219,7 +221,9 @@ def hwp_spin_up(state, block, disable_hwp=False, brake_hwp=True):
             duration += HWP_SPIN_DOWN
             cmds += COMMANDS_HWP_BRAKE if brake_hwp else COMMANDS_HWP_STOP
         else:
-            return state, 0, [f"# hwp already spinning with forward={state.hwp_dir}"]
+            direction = "ccw (positive frequency)" if state.hwp_dir \
+                else "cw (negative frequency)"
+            return state, 0, [f"# hwp already spinning " + direction]
 
     hwp_dir = block.hwp_dir if block.hwp_dir is not None else state.hwp_dir
     state = state.replace(hwp_dir=hwp_dir)


### PR DESCRIPTION
We plan to merge this PR https://github.com/simonsobs/ocs-deployment-configs/pull/436 in computing maintenance on 2025/5/8 to make the hwp rotation direction to be consistent between SATs. This will affect satp1 and satp2.

We have been using hwp-pid direction, Forward and Backward, as hwp direction terminology but this is not physically consistent with SO coords convention because of differences of instruments. The PR above will make SATs to have consistent relation (+/-) 2Hz to (ccw/cw seen from sky). To avoid confusion, I changed hwp_dir terminologies to (+/-), (ccw/cw).