### PR TITLE
Allow el_over_90 for LAT, prevent duplicate parking searches

### DIFF
--- a/src/schedlib/policies/lat.py
+++ b/src/schedlib/policies/lat.py
@@ -440,12 +440,6 @@ class LATPolicy(tel.TelPolicy):
                     return b.replace(alt=180-b.alt, az=b.az-180)
                 return b
             blocks = core.seq_map( fix_block, blocks)
-        else:
-            raise NotImplementedError(
-                "scheduler not implemented for boresight180 scans yet"
-                " schedules must be generated with elevations_under_90"
-                " set to True"
-            )
 
         if len(self.remove_targets) > 0:
             blocks = core.seq_filter_out(

--- a/src/schedlib/policies/stages/build_op.py
+++ b/src/schedlib/policies/stages/build_op.py
@@ -138,7 +138,10 @@ def get_safe_gaps(block0, block1, sun_policy, el_limits, is_end=False, max_delay
     alt_range = np.concatenate((alt_lower, alt_upper))
 
     # check 180, next, and current azimuths for parking
-    az_range = [180, block1.az, block0.az]
+    az_range = np.array([180, block1.az, block0.az])
+
+    _, idx = np.unique(az_range, return_index=True)
+    az_range = az_range[np.sort(idx)]
 
     for az_test in az_range:
         for alt_test in alt_range:


### PR DESCRIPTION
Branch to enable elevations > 90 degrees for the LAT.  Also included a minor fix to prevent duplicate azimuths from being searched when finding gap parking.