### PR TITLE
Relax sun-safety parameters for LAT

### DIFF
--- a/src/schedlib/policies/lat.py
+++ b/src/schedlib/policies/lat.py
@@ -360,8 +360,8 @@ def make_config(
     )
 
     sun_policy = {
-        'min_angle': 30,
-        'min_sun_time': 1980,
+        'min_angle': 21,
+        'min_sun_time': 1801,
         'min_el': 0,
         'max_el': 180,
         'min_az': -180+10,


### PR DESCRIPTION
Relaxes the exclusion radius and minimum sun-time sun-safety parameters to value that are similar to those in the ACU.  The values are kept slightly larger to avoid rounding errors.