### PR TITLE
Prevent duplicate logging for state functions

### DIFF
--- a/src/schedlib/utils.py
+++ b/src/schedlib/utils.py
@@ -306,10 +306,11 @@ def init_logger(name):
     logger = logging.getLogger(name)
     logger.propagate = False
     logger.setLevel(logging.INFO)
-    ch = logging.StreamHandler(sys.stdout)
-    formatter = logging.Formatter('%(asctime)s [%(levelname)s] %(message)s ')
-    ch.setFormatter(formatter)
-    logger.addHandler(ch)
+    if not logger.handlers:
+        ch = logging.StreamHandler(sys.stdout)
+        formatter = logging.Formatter('%(asctime)s [%(levelname)s] %(message)s ')
+        ch.setFormatter(formatter)
+        logger.addHandler(ch)
     return logger
 
 def set_logging_level(level=2):


### PR DESCRIPTION
Logging was being duplicated when using the `init_logger` function when called inside of the `get_sat_state`  and `get_lat_state` scripts.