### PR TITLE
Force scan params to be set at start when overriding motions

### DIFF
--- a/src/schedlib/commands.py
+++ b/src/schedlib/commands.py
@@ -348,8 +348,8 @@ def start_time(state):
     ]
 
 @operation(name='set_scan_params', duration=0)
-def set_scan_params(state, az_speed, az_accel):
-    if az_speed != state.az_speed_now or az_accel != state.az_accel_now:
+def set_scan_params(state, az_speed, az_accel, az_motion_override=False):
+    if az_speed != state.az_speed_now or az_accel != state.az_accel_now or az_motion_override:
         state = state.replace(az_speed_now=az_speed, az_accel_now=az_accel)
         return state, [ f"run.acu.set_scan_params({az_speed}, {az_accel})"]
     return state, []

--- a/src/schedlib/policies/lat.py
+++ b/src/schedlib/policies/lat.py
@@ -276,6 +276,7 @@ def make_cal_target(
 def make_operations(
     az_speed,
     az_accel,
+    az_motion_override,
     iv_cadence=4*u.hour,
     bias_step_cadence=0.5*u.hour,
     det_setup_duration=20*u.minute,
@@ -290,7 +291,7 @@ def make_operations(
     pre_session_ops = [
         { 'name': 'lat.preamble'        , 'sched_mode': SchedMode.PreSession, 'open_shutter': open_shutter},
         { 'name': 'start_time'          , 'sched_mode': SchedMode.PreSession},
-        { 'name': 'set_scan_params'     , 'sched_mode': SchedMode.PreSession, 'az_speed': az_speed, 'az_accel': az_accel, },
+        { 'name': 'set_scan_params'     , 'sched_mode': SchedMode.PreSession, 'az_speed': az_speed, 'az_accel': az_accel, 'az_motion_override': az_motion_override},
     ]
 
     cal_ops = []
@@ -359,6 +360,7 @@ def make_config(
 
     operations = make_operations(
         az_speed, az_accel,
+        az_motion_override,
         iv_cadence, bias_step_cadence,
         det_setup_duration,
         **op_cfg

--- a/src/schedlib/policies/satp1.py
+++ b/src/schedlib/policies/satp1.py
@@ -88,6 +88,7 @@ def make_cal_target(
 def make_operations(
     az_speed,
     az_accel,
+    az_motion_override=False,
     iv_cadence=4*u.hour,
     bias_step_cadence=0.5*u.hour,
     det_setup_duration=20*u.minute,
@@ -104,7 +105,7 @@ def make_operations(
     pre_session_ops = [
         { 'name': 'sat.preamble'        , 'sched_mode': SchedMode.PreSession},
         { 'name': 'start_time'          , 'sched_mode': SchedMode.PreSession},
-        { 'name': 'set_scan_params'     , 'sched_mode': SchedMode.PreSession, 'az_speed': az_speed, 'az_accel': az_accel, },
+        { 'name': 'set_scan_params'     , 'sched_mode': SchedMode.PreSession, 'az_speed': az_speed, 'az_accel': az_accel, 'az_motion_override': az_motion_override},
     ]
 
     cal_ops = []
@@ -180,6 +181,7 @@ def make_config(
 
     operations = make_operations(
         az_speed, az_accel,
+        az_motion_override,
         iv_cadence, bias_step_cadence,
         det_setup_duration,
         brake_hwp,

--- a/src/schedlib/policies/satp2.py
+++ b/src/schedlib/policies/satp2.py
@@ -88,6 +88,7 @@ def make_cal_target(
 def make_operations(
     az_speed,
     az_accel,
+    az_motion_override=False,
     iv_cadence=4*u.hour,
     bias_step_cadence=0.5*u.hour,
     det_setup_duration=20*u.minute,
@@ -104,7 +105,7 @@ def make_operations(
     pre_session_ops = [
         { 'name': 'sat.preamble'    , 'sched_mode': SchedMode.PreSession},
         { 'name': 'start_time'      , 'sched_mode': SchedMode.PreSession},
-        { 'name': 'set_scan_params' , 'sched_mode': SchedMode.PreSession, 'az_speed': az_speed, 'az_accel': az_accel, },
+        { 'name': 'set_scan_params' , 'sched_mode': SchedMode.PreSession, 'az_speed': az_speed, 'az_accel': az_accel, 'az_motion_override': az_motion_override},
     ]
 
     cal_ops = []
@@ -177,6 +178,7 @@ def make_config(
 
     operations = make_operations(
         az_speed, az_accel,
+        az_motion_override,
         iv_cadence, bias_step_cadence,
         det_setup_duration,
         brake_hwp,

--- a/src/schedlib/policies/satp3.py
+++ b/src/schedlib/policies/satp3.py
@@ -95,6 +95,7 @@ commands_det_setup = [
 def make_operations(
     az_speed,
     az_accel,
+    az_motion_override=False,
     iv_cadence=4*u.hour,
     bias_step_cadence=0.5*u.hour,
     det_setup_duration=20*u.minute,
@@ -112,7 +113,7 @@ def make_operations(
     pre_session_ops = [
         { 'name': 'sat.preamble'        , 'sched_mode': SchedMode.PreSession, },
         { 'name': 'start_time'          ,'sched_mode': SchedMode.PreSession},
-        { 'name': 'set_scan_params' , 'sched_mode': SchedMode.PreSession, 'az_speed': az_speed, 'az_accel': az_accel, },
+        { 'name': 'set_scan_params' , 'sched_mode': SchedMode.PreSession, 'az_speed': az_speed, 'az_accel': az_accel, 'az_motion_override': az_motion_override},
     ]
 
     cal_ops = []
@@ -186,6 +187,7 @@ def make_config(
 
     operations = make_operations(
         az_speed, az_accel,
+        az_motion_override,
         iv_cadence, bias_step_cadence,
         det_setup_duration,
         brake_hwp,


### PR DESCRIPTION
Addresses #243.  I only made this apply to the first `set_scan_params` as everything should be consistent after that.