### PR TITLE
Enable wiregrid time const measurement

### DIFF
--- a/src/schedlib/instrument.py
+++ b/src/schedlib/instrument.py
@@ -429,9 +429,7 @@ def parse_wiregrid_targets_from_file(ifile):
             t1=u.str2datetime(row['stop_utc']),
             tag=_escape_string(row['uid'].strip()),
         )
-        # temporarily disable wiregrid time const measurements
-        if wiregrid_target.name == 'wiregrid_gain':
-            wiregrid_targets.append(wiregrid_target)
+        wiregrid_targets.append(wiregrid_target)
 
     return wiregrid_targets
 

--- a/src/schedlib/policies/sat.py
+++ b/src/schedlib/policies/sat.py
@@ -332,14 +332,15 @@ def wiregrid(state, block, min_wiregrid_el=47.5):
         return state, (block.t1 - state.curr_time).total_seconds(), [
             "run.wiregrid.calibrate(continuous=False, elevation_check=True, boresight_check=False, temperature_check=False)"
         ]
-    # elif block.name == 'wiregrid_time_const':
-    #     # wiregrid time const reverses the hwp direction
-    #     state = state.replace(hwp_dir=not state.hwp_dir)
-    #     return state, (block.t1 - state.curr_time).total_seconds(), [
-    #         f"# hwp spinning with forward={not state.hwp_dir}",
-    #         "run.wiregrid.calibrate(continuous=False, elevation_check=True, boresight_check=False, temperature_check=False)",
-    #         f"# hwp spinning with forward={state.hwp_dir}"
-    #         ]
+    elif block.name == 'wiregrid_time_const':
+        # wiregrid time const reverses the hwp direction
+        state = state.replace(hwp_dir=not state.hwp_dir)
+        direction = "ccw (positive frequency)" if state.hwp_dir \
+                else "cw (negative frequency)"
+        return state, (block.t1 - state.curr_time).total_seconds(), [
+            "wiregrid.time_constant(num_repeats=1)",
+            f"# hwp direction reversed, now spinning " + direction,
+            ]
 
 @cmd.operation(name="move_to", return_duration=True)
 def move_to(state, az, el, az_offset=0, el_offset=0, min_el=48, brake_hwp=True, force=False):

--- a/src/schedlib/policies/sat.py
+++ b/src/schedlib/policies/sat.py
@@ -338,7 +338,7 @@ def wiregrid(state, block, min_wiregrid_el=47.5):
         direction = "ccw (positive frequency)" if state.hwp_dir \
                 else "cw (negative frequency)"
         return state, (block.t1 - state.curr_time).total_seconds(), [
-            "wiregrid.time_constant(num_repeats=1)",
+            "run.wiregrid.time_constant(num_repeats=1)",
             f"# hwp direction reversed, now spinning " + direction,
             ]
 

--- a/src/schedlib/policies/satp1.py
+++ b/src/schedlib/policies/satp1.py
@@ -457,10 +457,10 @@ class SATP1Policy(SATPolicy):
                     else:
                         raise ValueError("Cannot find nearby block for cal target")
 
-            if self.boresight_override is None:
-                wiregrid_candidates[i] = replace(wiregrid_candidates[i], boresight_rot=block.boresight_angle)
-            else:
-                wiregrid_candidates[i] = replace(wiregrid_candidates[i], boresight_rot=self.boresight_override)
+                if self.boresight_override is None:
+                    wiregrid_candidates[i] = replace(wiregrid_candidates[i], boresight_rot=block.boresight_angle)
+                else:
+                    wiregrid_candidates[i] = replace(wiregrid_candidates[i], boresight_rot=self.boresight_override)
 
             self.cal_targets += wiregrid_candidates
 

--- a/src/schedlib/policies/satp2.py
+++ b/src/schedlib/policies/satp2.py
@@ -456,10 +456,10 @@ class SATP2Policy(SATPolicy):
                     else:
                         raise ValueError("Cannot find nearby block for cal target")
 
-            if self.boresight_override is None:
-                wiregrid_candidates[i] = replace(wiregrid_candidates[i], boresight_rot=block.boresight_angle)
-            else:
-                wiregrid_candidates[i] = replace(wiregrid_candidates[i], boresight_rot=self.boresight_override)
+                if self.boresight_override is None:
+                    wiregrid_candidates[i] = replace(wiregrid_candidates[i], boresight_rot=block.boresight_angle)
+                else:
+                    wiregrid_candidates[i] = replace(wiregrid_candidates[i], boresight_rot=self.boresight_override)
 
             self.cal_targets += wiregrid_candidates
 


### PR DESCRIPTION
Enables the wiregrid time const measurements. Reverses the state hwp direction.