### PR TITLE
Remove target options because we can move in boresight again

### DIFF
--- a/src/schedlib/policies/satp1.py
+++ b/src/schedlib/policies/satp1.py
@@ -385,8 +385,6 @@ class SATP1Policy(SATPolicy):
             'saturn': {
                 0 : {
                     'ws0,ws4': False,
-                    'ws3': False,
-                    'ws5': False,
                 },
                 -45 : {
                     'ws0,ws3': False,


### PR DESCRIPTION
We can get ws3 and ws5 from boresight rotation now. 