### PR TITLE
Fix bug in source cycling

### DIFF
--- a/src/schedlib/policies/satp1.py
+++ b/src/schedlib/policies/satp1.py
@@ -422,7 +422,7 @@ class SATP1Policy(SATPolicy):
 
                 # get wafers to observe based on source name and boresight
                 focus_str = array_focus[cal_targets[i].source][cal_targets[i].boresight_rot]
-                index = u.get_cycle_option(t0, list(focus_str.keys()), anchor_time)
+                index = u.get_cycle_option(cal_target.t0, list(focus_str.keys()), anchor_time)
                 # order list so current date's array_query is tried first
                 array_query = list(focus_str.keys())[index:] + list(focus_str.keys())[:index]
                 #array_query = list(focus_str.keys())[index]

--- a/src/schedlib/policies/satp2.py
+++ b/src/schedlib/policies/satp2.py
@@ -424,7 +424,7 @@ class SATP2Policy(SATPolicy):
 
                 # get wafers to observe based on source name and boresight
                 focus_str = array_focus[cal_targets[i].source][cal_targets[i].boresight_rot]
-                index = u.get_cycle_option(t0, list(focus_str.keys()), anchor_time)
+                index = u.get_cycle_option(cal_target.t0, list(focus_str.keys()), anchor_time)
                 # order list so current date's array_query is tried first
                 array_query = list(focus_str.keys())[index:] + list(focus_str.keys())[:index]
                 #array_query = list(focus_str.keys())[index]

--- a/src/schedlib/policies/satp3.py
+++ b/src/schedlib/policies/satp3.py
@@ -397,7 +397,7 @@ class SATP3Policy(SATPolicy):
 
                 # get wafers to observe based on date
                 focus_str = array_focus
-                index = u.get_cycle_option(t0, list(focus_str.keys()), anchor_time)
+                index = u.get_cycle_option(cal_target.t0, list(focus_str.keys()), anchor_time)
                 # order list so current date's array_query is tried first
                 array_query = list(focus_str.keys())[index:] + list(focus_str.keys())[:index]
                 #array_query = list(focus_str.keys())[index]


### PR DESCRIPTION
Fixes a bug in selecting the wafers based on the date.  I checked SATp1 and it seems to have been cycling through its options, so this might not have affected too much in the auto-scheduler, but we should confirm.