### PR TITLE
Add ability to ignore wafers to SATs

### DIFF
--- a/src/schedlib/policies/satp2.py
+++ b/src/schedlib/policies/satp2.py
@@ -30,6 +30,7 @@ def make_cal_target(
     az_speed=None,
     az_accel=None,
     source_direction=None,
+    ignore_wafers=None,
 ) -> CalTarget:
     array_focus = {
         0 : {
@@ -54,6 +55,19 @@ def make_cal_target(
             'all' : 'ws0,ws1,ws2,ws3,ws4,ws5,ws6',
         },
     }
+
+    if ignore_wafers is not None:
+        for angle_key, focus_dict in array_focus.items():
+            keys_to_remove = []
+            for key, val in focus_dict.items():
+                wafers = val.split(',')
+                cleaned = [w for w in wafers if w not in ignore_wafers]
+                if cleaned:
+                    focus_dict[key] = ','.join(cleaned)
+                else:
+                    keys_to_remove.append(key)
+            for key in keys_to_remove:
+                focus_dict.pop(key)
 
     boresight = float(boresight)
     elevation = float(elevation)
@@ -351,7 +365,7 @@ class SATP2Policy(SATPolicy):
     def add_cal_target(self, *args, **kwargs):
         self.cal_targets.append(make_cal_target(*args, **kwargs))
 
-    def init_cal_seqs(self, cfile, wgfile, blocks, t0, t1, anchor_time=None):
+    def init_cal_seqs(self, cfile, wgfile, blocks, t0, t1, anchor_time=None, ignore_wafers=None):
         # source -> boresight -> allow_partial
         array_focus = {
             'jupiter': {
@@ -396,6 +410,18 @@ class SATP2Policy(SATPolicy):
                 }
             },
         }
+
+        if ignore_wafers is not None:
+            for outer_key in list(array_focus.keys()):
+                for inner_key in list(array_focus[outer_key].keys()):
+                    new_entries = {}
+                    for wafers_str, val in array_focus[outer_key][inner_key].items():
+                        wafers = wafers_str.split(',')
+                        filtered = [w for w in wafers if w not in ignore_wafers]
+                        if filtered:
+                            new_key = ','.join(filtered)
+                            new_entries[new_key] = val
+                    array_focus[outer_key][inner_key] = new_entries
 
         # get cal targets
         if cfile is not None:

--- a/src/schedlib/policies/satp3.py
+++ b/src/schedlib/policies/satp3.py
@@ -29,21 +29,32 @@ def make_cal_target(
     az_speed=None,
     az_accel=None,
     source_direction=None,
+    ignore_wafers=None,
 ) -> CalTarget:
     array_focus = {
         'left' : 'ws3,ws2',
         'middle' : 'ws0,ws1,ws4',
-        #'right' : 'ws5,ws6',
-        'right' : 'ws6',
-        #'top': 'ws3,ws4,ws5',
-        'top': 'ws3,ws4',
+        'right' : 'ws5,ws6',
+        'top': 'ws3,ws4,ws5',
         'toptop': 'ws4',
         'center': 'ws0',
         'bottom': 'ws1,ws2,ws6',
         'bottombottom': 'ws1',
-        #'all' : 'ws0,ws1,ws2,ws3,ws4,ws5,ws6',
-        'all' : 'ws0,ws1,ws2,ws3,ws4,ws6',
+        'all' : 'ws0,ws1,ws2,ws3,ws4,ws5,ws6',
     }
+
+    if ignore_wafers is not None:
+        keys_to_remove = []
+        for key, val in array_focus.items():
+            wafers = val.split(',')
+            cleaned = [w for w in wafers if w not in bad_wafers]
+            if cleaned:
+                array_focus[key] = ','.join(cleaned)
+            else:
+                keys_to_remove.append(key)
+
+        for key in keys_to_remove:
+            array_focus.pop(key)
 
     boresight = int(boresight)
     elevation = int(elevation)
@@ -365,7 +376,7 @@ class SATP3Policy(SATPolicy):
     def add_cal_target(self, *args, **kwargs):
         self.cal_targets.append(make_cal_target(*args, **kwargs))
 
-    def init_cal_seqs(self, cfile, wgfile, blocks, t0, t1, anchor_time=None):
+    def init_cal_seqs(self, cfile, wgfile, blocks, t0, t1, anchor_time=None, ignore_wafers=None):
         # wafer -> allow_partial
         array_focus = {
                 'ws0': False,
@@ -373,9 +384,13 @@ class SATP3Policy(SATPolicy):
                 'ws2': False,
                 'ws3': False,
                 'ws4': False,
-                #'ws5': False,
+                'ws5': False,
                 'ws6': False,
         }
+
+        if ignore_wafers is not None:
+            for wafer in ignore_wafers:
+                array_focus.pop(wafer, None)
 
         # get cal targets
         if cfile is not None:

--- a/src/schedlib/policies/satp3.py
+++ b/src/schedlib/policies/satp3.py
@@ -47,7 +47,7 @@ def make_cal_target(
         keys_to_remove = []
         for key, val in array_focus.items():
             wafers = val.split(',')
-            cleaned = [w for w in wafers if w not in bad_wafers]
+            cleaned = [w for w in wafers if w not in ignore_wafers]
             if cleaned:
                 array_focus[key] = ','.join(cleaned)
             else:


### PR DESCRIPTION
Can now specify `ignore_wafers` in the configuration file which is a list of all wafers to be excluded from being targeted.