### PR TITLE
Randomize divided block order

### DIFF
--- a/src/schedlib/policies/lat.py
+++ b/src/schedlib/policies/lat.py
@@ -692,6 +692,9 @@ class LATPolicy(tel.TelPolicy):
             is_leaf=lambda x: isinstance(x, list)
         )
 
+        # set the seed for shuffling blocks
+        self.rng = np.random.default_rng(t0.day)
+
         return blocks
 
     def apply(self, blocks: core.BlocksTree) -> core.BlocksTree:

--- a/src/schedlib/policies/sat.py
+++ b/src/schedlib/policies/sat.py
@@ -498,6 +498,9 @@ class SATPolicy(tel.TelPolicy):
             is_leaf=lambda x: isinstance(x, list)
         )
 
+        # set the seed for shuffling blocks
+        self.rng = np.random.default_rng(t0.day)
+
         return blocks
 
     def apply(self, blocks: core.BlocksTree) -> core.BlocksTree:

--- a/src/schedlib/policies/tel.py
+++ b/src/schedlib/policies/tel.py
@@ -9,8 +9,6 @@ from typing import List, Union, Optional, Dict, Any, Tuple
 import jax.tree_util as tu
 from functools import reduce
 
-import random
-
 from .. import config as cfg, core, source as src, rules as ru
 from .. import commands as cmd, instrument as inst, utils as u
 from ..thirdparty import SunAvoidance


### PR DESCRIPTION
Randomizes the order of divided blocks.  There are three cases:

- Block is too short to divide, so return only that block.
- Split into two blocks, smaller block was previously appended to the end of the list - > just randomly shuffle this.
- Split into many blocks.  If remainder is large enough, divide a block to have two >= 30 min blocks at the start and end of the sequence.  Fill the rest with the 1 hour blocks. Now just randomly shuffle all of the blocks, since it doesn't matter what order we do the 1 hour ones in and the remainders will get placed at random between them.

I set the seed to be the day of `t0`, so that things are reproducible for debugging and tracking schedules over the longterm.