### PR TITLE
Fix az wrapping for CMB obs

### DIFF
--- a/src/schedlib/policies/lat.py
+++ b/src/schedlib/policies/lat.py
@@ -805,7 +805,7 @@ class LATPolicy(tel.TelPolicy):
         if 'az-range' in self.rules:
             logger.info(f"applying az range rule: {self.rules['az-range']}")
             az_range = ru.AzRange(**self.rules['az-range'])
-            blocks['calibration'] = az_range(blocks['calibration'])
+            blocks = az_range(blocks)
 
         # -----------------------------------------------------------------
         # step 4: tags

--- a/src/schedlib/policies/sat.py
+++ b/src/schedlib/policies/sat.py
@@ -662,7 +662,7 @@ class SATPolicy(tel.TelPolicy):
         if 'az-range' in self.rules:
             logger.info(f"applying az range rule: {self.rules['az-range']}")
             az_range = ru.AzRange(**self.rules['az-range'])
-            blocks['calibration'] = az_range(blocks['calibration'])
+            blocks = az_range(blocks)
 
         # -----------------------------------------------------------------
         # step 4: tags


### PR DESCRIPTION
Checks the full range of az for CMB obs instead of just the first az using the az range rule like the calibration.  Also reorganizes the gap position checking as the az range change causes a sun-safety issue since it cannot go from az=-60 to az=210 degrees easily.

Note this changes the tags so they have the wrapped azimuth. We can do this at a later step if we want the original tags, but since we have the uids I'm not sure it is necessary.