### PR TITLE
Overhaul sun-safety

### DIFF
--- a/src/schedlib/instrument.py
+++ b/src/schedlib/instrument.py
@@ -358,7 +358,7 @@ def parse_sequence_from_toast_sat(ifile):
     df = pd.read_csv(ifile, skiprows=i, delimiter="|", names=columns, comment='#')
     blocks = []
     for _, row in df.iterrows():
-        if row['type'] != "None":
+        if _escape_string(row['type'].strip()) != "None":
             block = ScanBlock(
                 name=_escape_string(row['patch'].strip()),
                 t0=u.str2datetime(row['start_utc']),

--- a/src/schedlib/policies/stages/build_op.py
+++ b/src/schedlib/policies/stages/build_op.py
@@ -202,7 +202,7 @@ def get_safe_gaps(block0, block1, sun_policy, el_limits, is_end=False, max_delay
     # drifted_az = block0.block.az + block0.block.throw + block0.block.az_drift * ((block0.block.t1 - block0.block.t0).total_seconds())
 
     # check 180, next, and current azimuths for parking
-    az_range = np.array([-45, 180, az_strict, block1.az])
+    az_range = np.array([180, az_strict, block1.az])
 
     _, idx = np.unique(az_range, return_index=True)
     az_range = az_range[np.sort(idx)]

--- a/src/schedlib/policies/stages/build_op.py
+++ b/src/schedlib/policies/stages/build_op.py
@@ -722,7 +722,7 @@ class BuildOpSimple:
 
         # for how long is this block sun-safe
         _, sun_safe, _ = get_traj_ok_time_socs(block.az, block.az, block.alt, block.alt, block.t1,
-                                       self.plan_moves['sun_policy'], block0=block, return_all=True, check_move=False)
+                                       self.plan_moves['sun_policy'], block0=block, return_all=True)
         final_safet = u.ct2dt(u.dt2ct(block.t1) + sun_safe['sun_time'])
 
         initial_state = state

--- a/src/schedlib/policies/stages/build_op.py
+++ b/src/schedlib/policies/stages/build_op.py
@@ -67,7 +67,7 @@ def get_traj_ok_time(az0, az1, alt0, alt1, t0, sun_policy, block0=None):
 
     return u.ct2dt(u.dt2ct(t0) + sun_safety['sun_time'])
 
-def get_traj_ok_time_socs(az0, az1, alt0, alt1, t0, sun_policy, block0=None, return_all=False, check_move=False):
+def get_traj_ok_time_socs(az0, az1, alt0, alt1, t0, sun_policy, block0=None, return_all=False):
     # Returns the timestamp until which the move from (az0, alt0) to
     # (az1, alt1) is sunsafe using socs sun-safety checker.  If block0 is
     # passed it will check the start and end azimuths of a scan if it can
@@ -223,6 +223,10 @@ def get_safe_gaps(block0, block1, sun_policy, el_limits, is_end=False, max_delay
             move_away_by = get_traj_ok_time_socs(block0.az, az_parking, block0.alt,
                                                  alt_parking, block0.t1, sun_policy,
                                                  block0)
+
+            if move_away_by == block0.t1:
+                continue
+
             if move_away_by < t0_parking:
                 if move_away_by <= block0.t1:
                     logger.info("move away time <= block0.t1")

--- a/src/schedlib/policies/stages/build_op.py
+++ b/src/schedlib/policies/stages/build_op.py
@@ -217,7 +217,6 @@ def get_safe_gaps(block0, block1, sun_policy, el_limits, is_end=False, max_delay
             if parking is not None:
                 az_parking, alt_parking, t0_parking, t1_parking = parking
             else:
-                logger.info("parking at ({np.round(az_test,1)}, {alt_test}) is not safe")
                 continue
 
             # you might need to rush away from final position...

--- a/src/schedlib/policies/tel.py
+++ b/src/schedlib/policies/tel.py
@@ -370,7 +370,8 @@ def bias_step(state, block, bias_step_cadence=None):
             last_bias_step_elevation = block.alt,
             last_bias_step_boresight = block.boresight_angle,
         )
-        return state, 60, [ "run.smurf.bias_step(concurrent=True)", ]
+        return state, 60, [ "run.smurf.bias_step(concurrent=True)",
+                            f"run.wait_until('{(state.curr_time + dt.timedelta(seconds=60)).isoformat(timespec='seconds')}')"]
     else:
         return state, 0, []
 


### PR DESCRIPTION
Fixes some inconsistencies with sun-safety.  The sun-rule at the start checks whether movement within a scan's az, alt box is sun-safe, which is a moving target on the sky when there is drift.  Therefore, when considering the move from one scan to a next, you need to calculate the drifted az at the end of that scan and use that to check the move.  This was sort of done in a previous sun-safety PR I did, but wasn't quite correct.  For this reason, the sun-safety from the sun-rule was much larger than the sun-safety from the trajectory calculation.  Previously, the trajectory sun-safety was checking both the start and end azimuths of the first block at the end time of the first block, but this should be unnecessary since this will always be sun-safety checked when moving to that block.

Also, instead of just now checking if a block extends past its constraint, it now checks if it extends past the minimum of the constraint or the sun-safety periods and will limit the block size to make sure it fits.  Ths is necessary since bias_steps occur after calibration observations and are at the same az, el.  However, these are not taken into account in the sun_rule sun-safety so they are tacked onto the end of the sun-safety time.  This will likely cut 1 minute off of many calibration scans since they often cover the full sun-safe limits.  I will try to find a way to do this up-front instead.

Example config that this now works for:

```
platform: satp1

# yaml loads iso format automatically into datetimes
t0: 2025-08-13T00:00:00+00:00
t1: 2025-08-14T00:00:00+00:00
t0_state_file: None
#t0_state_file: satp1/state_files/state_2025-04-18T16:00:00+00:00.npy

elevation: 60
min_hwp_el: 48

use_cal_file: True
use_wiregrid_file: True

# optional, only needed if running non-defaults
#hwp_override: False # True: positive frequency, False: negative frequency
az_motion_override: False # True: overwrite azspeed as set above, False: use
#azspeed written in the master schedule.
relock_cadence: 84400 #86400 # Relock every 24 hours
#home_at_end: True # Home: spin down HWP and go to (180,60)
bias_step_cadence: 1800
```