### PR TITLE
Fix wiregrid overlap and durations

### DIFF
--- a/src/schedlib/policies/sat.py
+++ b/src/schedlib/policies/sat.py
@@ -815,7 +815,14 @@ class SATPolicy(tel.TelPolicy):
         cmb_blocks = core.seq_flatten(core.seq_filter(lambda b: b.subtype == 'cmb', seq))
 
         wiregrid_blocks = core.seq_flatten(core.seq_filter(lambda b: b.subtype == 'wiregrid', seq))
-        cal_blocks =  core.seq_sort(core.seq_merge(cal_blocks, wiregrid_blocks, flatten=True))
+
+        for i, wiregrid_block in enumerate(wiregrid_blocks):
+            if core.seq_has_overlap_with_block(cal_blocks, wiregrid_block):
+                logger.warn(f"wiregrid block {wiregrid_block} has overlap with cal scans. removing.")
+                wiregrid_blocks[i] = None
+
+        cal_blocks += wiregrid_blocks
+
         seq = core.seq_sort(core.seq_merge(cmb_blocks, cal_blocks, flatten=True))
 
         # divide cmb blocks

--- a/src/schedlib/policies/sat.py
+++ b/src/schedlib/policies/sat.py
@@ -815,7 +815,7 @@ class SATPolicy(tel.TelPolicy):
         cmb_blocks = core.seq_flatten(core.seq_filter(lambda b: b.subtype == 'cmb', seq))
 
         wiregrid_blocks = core.seq_flatten(core.seq_filter(lambda b: b.subtype == 'wiregrid', seq))
-        cal_blocks += wiregrid_blocks
+        cal_blocks =  core.seq_sort(core.seq_merge(cal_blocks, wiregrid_blocks, flatten=True))
         seq = core.seq_sort(core.seq_merge(cmb_blocks, cal_blocks, flatten=True))
 
         # divide cmb blocks

--- a/src/schedlib/policies/sat.py
+++ b/src/schedlib/policies/sat.py
@@ -320,7 +320,7 @@ def wiregrid(state, block, min_wiregrid_el=47.5):
     assert block.alt >= min_wiregrid_el, f"Block {block} is below the minimum wiregrid elevation of {min_wiregrid_el} degrees."
 
     if block.name == 'wiregrid_gain':
-        return state, (block.t1 - state.curr_time).total_seconds(), [
+        return state, block.duration.total_seconds(), [
             "run.wiregrid.calibrate(continuous=False, elevation_check=True, boresight_check=False, temperature_check=False)"
         ]
     elif block.name == 'wiregrid_time_const':
@@ -328,7 +328,7 @@ def wiregrid(state, block, min_wiregrid_el=47.5):
         state = state.replace(hwp_dir=not state.hwp_dir)
         direction = "ccw (positive frequency)" if state.hwp_dir \
                 else "cw (negative frequency)"
-        return state, (block.t1 - state.curr_time).total_seconds(), [
+        return state, block.duration.total_seconds(), [
             "run.wiregrid.time_constant(num_repeats=1)",
             f"# hwp direction reversed, now spinning " + direction,
             ]


### PR DESCRIPTION
We have started running into a problem where the wiregrid measurements overlap with a calibration measurement.

This fixes it by removing the wiregrid block entirely in the event of overlap with a calibration target.  The wiregrid measurements do not have a stop time, so they will always runt their full duration, so they will always overwrite portions of other blocks unless removed.

Also changes the durations to make them reflect the fact that the wiregrid measurements will always run to their full duration.