### PR TITLE
Enforce HWP movement limits

### DIFF
--- a/src/schedlib/policies/lat.py
+++ b/src/schedlib/policies/lat.py
@@ -886,7 +886,7 @@ class LATPolicy(tel.TelPolicy):
                 f"of {alt_limits[0]} degrees."
                 )
 
-                assert block.alt < alt_limits[1], (
+                assert block.alt <= alt_limits[1], (
                 f"Block {block} is above the maximum elevation "
                 f"of {alt_limits[1]} degrees."
                 )

--- a/src/schedlib/policies/satp1.py
+++ b/src/schedlib/policies/satp1.py
@@ -185,6 +185,8 @@ def make_config(
     max_cmb_scan_duration,
     cal_targets,
     min_hwp_el=None,
+    max_hwp_el=None,
+    force_max_hwp_el=False,
     az_stow=None,
     el_stow=None,
     az_offset=0.,
@@ -239,8 +241,13 @@ def make_config(
         'az_range': [-45, 405]
     }
 
+    if force_max_hwp_el and max_hwp_el is not None:
+        max_el  = max_hwp_el
+    else:
+        max_el = 90
+
     el_range = {
-        'el_range': [40, 90]
+        'el_range': [40, max_el]
     }
 
     config = {
@@ -269,6 +276,7 @@ def make_config(
         'iv_cadence': iv_cadence,
         'bias_step_cadence': bias_step_cadence,
         'min_hwp_el': min_hwp_el,
+        'max_hwp_el': max_hwp_el,
         'max_cmb_scan_duration': max_cmb_scan_duration,
         'az_branch_override': az_branch_override,
         'allow_partial_override': allow_partial_override,
@@ -310,6 +318,8 @@ class SATP1Policy(SATPolicy):
         max_cmb_scan_duration=1*u.hour,
         cal_targets=None,
         min_hwp_el=48,
+        max_hwp_el=60,
+        force_max_hwp_el=False,
         az_stow=None,
         el_stow=None,
         az_offset=0.,
@@ -340,6 +350,8 @@ class SATP1Policy(SATPolicy):
             max_cmb_scan_duration,
             cal_targets,
             min_hwp_el,
+            max_hwp_el,
+            force_max_hwp_el,
             az_stow,
             el_stow,
             az_offset,

--- a/src/schedlib/policies/satp2.py
+++ b/src/schedlib/policies/satp2.py
@@ -185,6 +185,8 @@ def make_config(
     max_cmb_scan_duration,
     cal_targets,
     min_hwp_el=None,
+    max_hwp_el=None,
+    force_max_hwp_el=False,
     az_stow=None,
     el_stow=None,
     az_offset=0.,
@@ -240,8 +242,13 @@ def make_config(
         'az_range': [-45, 405]
     }
 
+    if force_max_hwp_el and max_hwp_el is not None:
+        max_el  = max_hwp_el
+    else:
+        max_el = 90
+
     el_range = {
-        'el_range': [40, 90]
+        'el_range': [40, max_el]
     }
 
     config = {
@@ -270,6 +277,7 @@ def make_config(
         'iv_cadence' : iv_cadence,
         'bias_step_cadence' : bias_step_cadence,
         'min_hwp_el' : min_hwp_el,
+        'max_hwp_el': max_hwp_el,
         'max_cmb_scan_duration' : max_cmb_scan_duration,
         'az_branch_override': az_branch_override,
         'allow_partial_override': allow_partial_override,
@@ -311,6 +319,8 @@ class SATP2Policy(SATPolicy):
         max_cmb_scan_duration=1*u.hour,
         cal_targets=None,
         min_hwp_el=48,
+        max_hwp_el=60,
+        force_max_hwp_el=False,
         az_stow=None,
         el_stow=None,
         az_offset=0.,
@@ -342,6 +352,8 @@ class SATP2Policy(SATPolicy):
             max_cmb_scan_duration,
             cal_targets,
             min_hwp_el,
+            max_hwp_el,
+            force_max_hwp_el,
             az_stow,
             el_stow,
             az_offset,

--- a/src/schedlib/policies/satp3.py
+++ b/src/schedlib/policies/satp3.py
@@ -192,6 +192,8 @@ def make_config(
     max_cmb_scan_duration,
     cal_targets,
     min_hwp_el=None,
+    max_hwp_el=None,
+    force_max_hwp_el=False,
     az_stow=None,
     el_stow=None,
     az_offset=0.,
@@ -251,8 +253,13 @@ def make_config(
         'az_range': [-45, 405]
     }
 
+    if force_max_hwp_el and max_hwp_el is not None:
+        max_el  = max_hwp_el
+    else:
+        max_el = 90
+
     el_range = {
-        'el_range': [40, 90]
+        'el_range': [40, max_el]
     }
 
     config = {
@@ -281,6 +288,7 @@ def make_config(
         'iv_cadence': iv_cadence,
         'bias_step_cadence': bias_step_cadence,
         'min_hwp_el': min_hwp_el,
+        'max_hwp_el': max_hwp_el,
         'max_cmb_scan_duration': max_cmb_scan_duration,
         'az_branch_override': az_branch_override,
         'allow_partial_override': allow_partial_override,
@@ -322,6 +330,8 @@ class SATP3Policy(SATPolicy):
         max_cmb_scan_duration=1*u.hour,
         cal_targets=None,
         min_hwp_el=48,
+        max_hwp_el=60,
+        force_max_hwp_el=False,
         az_stow=None,
         el_stow=None,
         az_offset=0.,
@@ -351,7 +361,10 @@ class SATP3Policy(SATPolicy):
             iv_cadence,
             bias_step_cadence,
             max_cmb_scan_duration,
-            cal_targets, min_hwp_el,
+            cal_targets,
+            min_hwp_el,
+            max_hwp_el,
+            force_max_hwp_el,
             az_stow,
             el_stow,
             az_offset,

--- a/src/schedlib/policies/stages/build_op.py
+++ b/src/schedlib/policies/stages/build_op.py
@@ -245,17 +245,29 @@ def get_safe_gaps(block0, block1, sun_policy, el_limits, is_end=False, max_delay
     alt_step = 4
     if block0.alt <= 90:
         alt_lower = np.arange(block0.alt, sun_policy['min_el'] - alt_step, -alt_step)
-        alt_lower[-1] = sun_policy['min_el']
+        if len(alt_lower) > 0:
+            alt_lower[-1] = sun_policy['min_el']
+        else:
+            alt_lower = [sun_policy['min_el']]
     else:
         alt_lower = np.arange(block0.alt, el_limits[-1] + alt_step, alt_step)
-        alt_lower[-1] = el_limits[-1]
+        if len(alt_lower) > 0:
+            alt_lower[-1] = el_limits[-1]
+        else:
+            alt_lower = [el_limits[-1]]
 
     if block0.alt <= 90:
         alt_upper = np.arange(block0.alt + alt_step, el_limits[-1] + alt_step, alt_step)
-        alt_upper[-1] = el_limits[-1]
+        if len(alt_upper) > 0:
+            alt_upper[-1] = el_limits[-1]
+        else:
+            alt_upper = [el_limits[-1]]
     else:
         alt_upper = np.arange(block0.alt, sun_policy['min_el'] - alt_step, -alt_step)
-        alt_upper[-1] = sun_policy['min_el']
+        if len(alt_upper) > 0:
+            alt_upper[-1] = sun_policy['min_el']
+        else:
+            alt_upper = [sun_policy['min_el']]
 
     alt_range = np.concatenate((alt_lower, alt_upper))
     # drifted_az = block0.block.az + block0.block.throw + block0.block.az_drift * ((block0.block.t1 - block0.block.t0).total_seconds())
@@ -931,6 +943,8 @@ class BuildOpSimple:
                 # add min hwp elevation if present
                 if hasattr(self.policy_config, 'min_hwp_el'):
                     op_cfgs[0]['min_el'] = self.policy_config.min_hwp_el
+                if hasattr(self.policy_config, 'max_hwp_el'):
+                    op_cfgs[0]['max_el'] = self.policy_config.max_hwp_el
                 if hasattr(self.policy_config, 'brake_hwp'):
                     op_cfgs[0]['brake_hwp'] = self.policy_config.brake_hwp
                 state, _, op_blocks = self._apply_ops(state, op_cfgs, az=ir.az, alt=ir.alt)


### PR DESCRIPTION
Adds `max_hwp_el` which will force the HWP to spin down if it tries to go above that limit.  Also adds `force_max_hwp_el` which makes sure all obs and move are at or below `max_hwp_el` in case you don't want to trigger a spin down and just want everything below that limit.