### PR TITLE
Fix az wrapping for drift

### DIFF
--- a/src/schedlib/policies/stages/build_op.py
+++ b/src/schedlib/policies/stages/build_op.py
@@ -1012,6 +1012,7 @@ class PlanMoves:
                 az_unwrap = find_unwrap(b.az, az_limits=self.az_limits)[0]
                 logger.info(f"-> unwrapping az: {b.az} -> {az_unwrap}")
                 seq_ += [b.replace(az=az_unwrap)]
+                seq_[-1].replace(block=b.block.replace(az=az_unwrap))
             else:
                 seq_ += [b]
         seq = seq_

--- a/src/schedlib/policies/stages/build_op.py
+++ b/src/schedlib/policies/stages/build_op.py
@@ -1000,7 +1000,14 @@ class PlanMoves:
         seq_ = []
         for b in seq:
             drifted_az = b.az + b.block.throw + b.block.az_drift * ((b.t1 - b.t0).total_seconds())
-            if b.az < self.az_limits[0] or b.az > self.az_limits[1] or (drifted_az < self.az_limits[0]) or (drifted_az > self.az_limits[1]):
+            if (
+                b.az < self.az_limits[0]
+                or b.az > self.az_limits[1]
+                or drifted_az < self.az_limits[0]
+                or drifted_az > self.az_limits[1]
+                or b.az + b.block.throw < self.az_limits[0]
+                or b.az + b.block.throw > self.az_limits[1]
+            ):
                 logger.info(f"block az ({b.az}) outside limits, unwrapping...")
                 az_unwrap = find_unwrap(b.az, az_limits=self.az_limits)[0]
                 logger.info(f"-> unwrapping az: {b.az} -> {az_unwrap}")

--- a/src/schedlib/rules.py
+++ b/src/schedlib/rules.py
@@ -57,9 +57,7 @@ class AzRange(core.MappableRule):
         def get_best_az(az, throw, az_limit, wrap=360):
             # see if wrapping around helps
             az_best = az
-            print(np.arange(az, az_limit, wrap))
             for az_ in np.arange(az, az_limit, wrap):
-                print(az_, is_good(az_, throw))
                 # ideal case: find full coverage after 2pi wrapping
                 if is_good(az_, throw):
                     return block.replace(az=az_)


### PR DESCRIPTION
The az range rule now not only checks just the initial and drifted az at the end of the scan, but also `az + throw`, since just checking the others can result in a scan going outside the bounds if the drift is negative and the throw is positive.