### PR TITLE
Sun safety and gap changes

### DIFF
--- a/src/schedlib/policies/lat.py
+++ b/src/schedlib/policies/lat.py
@@ -471,7 +471,7 @@ def make_config(
                 'plan_moves': {
                     'stow_position': stow_position,
                     'sun_policy': sun_policy,
-                    'az_step': 0.5,
+                    'alt_step': 10,
                     'az_limits': az_range['az_range'],
                     'el_limits': el_range['el_range'],
                 }

--- a/src/schedlib/policies/sat.py
+++ b/src/schedlib/policies/sat.py
@@ -549,7 +549,6 @@ class SATPolicy(tel.TelPolicy):
         logger.info("planning calibration scans...")
         cal_blocks = []
 
-        saved_cal_targets = []
         for target in self.cal_targets:
             logger.info(f"-> planning calibration scans for {target}...")
 
@@ -623,7 +622,6 @@ class SATPolicy(tel.TelPolicy):
                     )
 
                 cal_blocks.append(cal_block)
-                saved_cal_targets.append(target)
 
                 # don't test other array queries if we have one that works
                 break
@@ -864,7 +862,7 @@ class SATPolicy(tel.TelPolicy):
             'pre': [],
             'in': [],
             'post': pre_sess,  # scheduled after t0
-            'priority': -1,
+            'priority': -2,
             'pinned': True  # remain unchanged during multi-pass
         }
 
@@ -895,7 +893,7 @@ class SATPolicy(tel.TelPolicy):
             'pre': pos_sess, # scheduled before t1
             'in': [],
             'post': [],
-            'priority': -1,
+            'priority': -2,
             'pinned': True # remain unchanged during multi-pass
         }
         seq = [start_block] + seq + [end_block]

--- a/src/schedlib/policies/satp1.py
+++ b/src/schedlib/policies/satp1.py
@@ -288,7 +288,7 @@ def make_config(
                 'plan_moves': {
                     'stow_position': stow_position,
                     'sun_policy': sun_policy,
-                    'az_step': 0.5,
+                    'alt_step': 4,
                     'az_limits': az_range['az_range'],
                     'el_limits': el_range['el_range'],
                 }

--- a/src/schedlib/policies/satp2.py
+++ b/src/schedlib/policies/satp2.py
@@ -289,7 +289,7 @@ def make_config(
                 'plan_moves': {
                     'stow_position': stow_position,
                     'sun_policy': sun_policy,
-                    'az_step': 0.5,
+                    'alt_step': 4,
                     'az_limits': az_range['az_range'],
                     'el_limits': el_range['el_range'],
                 }

--- a/src/schedlib/policies/satp3.py
+++ b/src/schedlib/policies/satp3.py
@@ -300,7 +300,7 @@ def make_config(
                 'plan_moves': {
                     'stow_position': stow_position,
                     'sun_policy': sun_policy,
-                    'az_step': 0.5,
+                    'alt_step': 4,
                     'az_limits': az_range['az_range'],
                     'el_limits': el_range['el_range'],
                 }

--- a/src/schedlib/policies/stages/build_op.py
+++ b/src/schedlib/policies/stages/build_op.py
@@ -434,8 +434,8 @@ class IRMode:
     Gap = 'gap'
     Aux = 'aux'
 
-# custom exceptions
-class SunSafeError(Exception):
+# base exception for errors
+class SchedError(Exception):
     def __init__(self, message, block0=None, block1=None):
         super().__init__(message)
         self.block0 = block0
@@ -450,21 +450,14 @@ class SunSafeError(Exception):
         else:
             return base_message
 
-# custom exceptions
-class NoGapError(Exception):
-    def __init__(self, message, block0=None, block1=None):
-        super().__init__(message)
-        self.block0 = block0
-        self.block1 = block1
 
-    def __str__(self):
-        base_message = super().__str__()
-        if self.block0 and self.block1:
-            return f"{base_message} (Block: {self.block0} -> {self.block1})"
-        elif self.block0:
-            return f"{base_message} (Block: {self.block0})"
-        else:
-            return base_message
+class SunSafeError(SchedError):
+    """Raised when a plan violates sun-safety constraints."""
+
+
+class NoGapError(SchedError):
+    """Raised when no safe gap could be found between blocks."""
+
 
 @dataclass(frozen=True)
 class BuildOpSimple:

--- a/src/schedlib/policies/stages/build_op.py
+++ b/src/schedlib/policies/stages/build_op.py
@@ -228,7 +228,7 @@ def get_parking(t0, t1, alt0, sun_policy, az_parking=180, alt_parking=None, bloc
 
 def get_safe_gaps(block0, block1, sun_policy, el_limits, is_end=False, max_delay=300, alt_step=4):
     # Check the move
-    t1, _, az_strict = get_traj_ok_time_socs_move(block0.az, block1.az, block0.alt, block1.alt,
+    t1, _, az_strict = get_traj_ok_time_socs_scan(block0.az, block1.az, block0.alt, block1.alt,
                                block0.t1, sun_policy, block0, return_all=True)
 
     # if previous block runs into or beyond next block
@@ -279,7 +279,7 @@ def get_safe_gaps(block0, block1, sun_policy, el_limits, is_end=False, max_delay
         az_range = np.array([180, az_strict, block1.az])
     else:
         # check a wide range of parking positions of max_delay = 0
-        az_range = np.array([180, az_strict, block1.az, 0, 90, 270])
+        az_range = np.array([180, az_strict, block1.az, 90, 270])
 
     _, idx = np.unique(az_range, return_index=True)
     az_range = az_range[np.sort(idx)]
@@ -298,7 +298,7 @@ def get_safe_gaps(block0, block1, sun_policy, el_limits, is_end=False, max_delay
                 continue
 
             # you might need to rush away from final position...
-            move_away_by, move, _ = get_traj_ok_time_socs_move(block0.az, az_parking, block0.alt,
+            move_away_by, move, _ = get_traj_ok_time_socs_scan(block0.az, az_parking, block0.alt,
                     alt_parking, block0.t1, sun_policy, block0=block0, return_all=True)
 
             if (
@@ -316,7 +316,7 @@ def get_safe_gaps(block0, block1, sun_policy, el_limits, is_end=False, max_delay
                 # You might need to wait until the last second before going to new pos
                 shift = 10.
                 while t1_parking < block1.t0 + dt.timedelta(seconds=max_delay):
-                    ok_until, move, _ = get_traj_ok_time_socs_move(
+                    ok_until, move, _ = get_traj_ok_time_socs_scan(
                         az_parking, block1.az, alt_parking, block1.alt, t1_parking, sun_policy, return_all=True)
                     if (
                         ok_until >= block1.t0
@@ -330,7 +330,7 @@ def get_safe_gaps(block0, block1, sun_policy, el_limits, is_end=False, max_delay
                     logger.info(f"reached max delay")
                     continue
             else:
-                ok_until, move, _ = get_traj_ok_time_socs_move(
+                ok_until, move, _ = get_traj_ok_time_socs_scan(
                     az_parking, block1.az, alt_parking, block1.alt, t1_parking, sun_policy, return_all=True)
 
                 if (

--- a/src/schedlib/quality_assurance/sun_safety_checker.py
+++ b/src/schedlib/quality_assurance/sun_safety_checker.py
@@ -58,7 +58,7 @@ class SunCrawler:
         self.cur_az = 0
         self.cur_el = 0
 
-        self.MAX_SUN_MAP_TDELTA = 6.*3600.
+        self.MAX_SUN_MAP_TDELTA = 1.*3600.
 
         self._get_initial_pos()
         self._generate_sun_solution()


### PR DESCRIPTION
More reworking of sun-safety and gaps.  There was an issue with moving between some LAT scans (https://github.com/simonsobs/LAT-scan-schedules/blob/b27d9fae66a8adacd929e6d72bf18873f412a90b/iso/phase2/2025-07-23T14%3A39%3A08%2B00%3A00_phase2_cmb_lat_field_schedule.txt#L378-L379).  This occurs when one scan runs directly into another so the gap duration is zero but it can't go from one scan to the next directly, so it finds an intermediate point.  The logic has been updated to support this.

Also, there was an inconsistency in what the `socs` avoidance tracker returned inside of `scheduler` and at the end.  This appears to be due to how often the sun tracker gets reset in the end sun safety checker.  This reduces it to reset every hour instead of 6 which solved the inconsistency.

This still can't solve some of the issues, such as between these scans:
https://github.com/simonsobs/LAT-scan-schedules/blob/b27d9fae66a8adacd929e6d72bf18873f412a90b/iso/phase2/2025-07-23T14%3A39%3A08%2B00%3A00_phase2_cmb_lat_field_schedule.txt#L518-L519

I tested with a simple script that only calls the `socs` avoidance code for a range of gap positions and found no possible intermediate positions between the locations (note the first scan gets unwrapped).