### PR TITLE
Update sun tracker refresh time

### DIFF
--- a/src/schedlib/policies/sat.py
+++ b/src/schedlib/policies/sat.py
@@ -791,7 +791,6 @@ class SATPolicy(tel.TelPolicy):
         # first resolve overlapping between cal and cmb
         cal_blocks = core.seq_flatten(core.seq_filter(lambda b: b.subtype == 'cal', seq))
         cmb_blocks = core.seq_flatten(core.seq_filter(lambda b: b.subtype == 'cmb', seq))
-
         wiregrid_blocks = core.seq_flatten(core.seq_filter(lambda b: b.subtype == 'wiregrid', seq))
 
         for i, wiregrid_block in enumerate(wiregrid_blocks):

--- a/src/schedlib/policies/satp3.py
+++ b/src/schedlib/policies/satp3.py
@@ -489,6 +489,7 @@ class SATP3Policy(SATPolicy):
                     f" {t0}"
                 )
                 state = state.replace(curr_time = t0)
+
             return state
 
         return State(

--- a/src/schedlib/policies/stages/build_op.py
+++ b/src/schedlib/policies/stages/build_op.py
@@ -1081,7 +1081,6 @@ class PlanMoves:
                 gaps = get_safe_gaps(seq[i-1], seq[i], self.sun_policy, self.el_limits,
                                 is_end=(i==(len(seq)-1)), max_delay=1200, alt_step=self.alt_step, sungod=sungod)
             if gaps is None:
-                end = time.time()
                 raise NoGapError(f"No sun-safe gap found between '{seq[i-1].block.name}' and '{seq[i].block.name}'", seq[i-1], seq[i])
             seq_.extend(gaps)
             seq_.append(seq[i])

--- a/src/schedlib/policies/tel.py
+++ b/src/schedlib/policies/tel.py
@@ -172,6 +172,7 @@ def wrap_up(state, block):
     ]
 
 def ufm_relock(state, commands=None, relock_cadence=24*u.hour):
+
     doit = False
     if state.last_ufm_relock is None:
         doit = True

--- a/src/schedlib/thirdparty/avoidance.py
+++ b/src/schedlib/thirdparty/avoidance.py
@@ -41,7 +41,7 @@ DEFAULT_POLICY = {
     'response_time': HOUR * 4,
 }
 
-REFRESH_INTERVAL = HOUR * 6
+REFRESH_INTERVAL = HOUR * 1
 
 def get_sun_tracker(t_lookup, policy=None) -> "SunTracker":
     """
@@ -84,6 +84,7 @@ class SunAvoidance(core.MappableRule):
             # At each minute, assess sun-safety
             t, az_left, az_right, alt_min, alt_max = \
                 block.get_az_alt_extent(time_step=self.time_step * 60)
+
             # Confirm alt is constant...
             alt = alt_min[0]
             assert np.all(alt == np.array([alt_max, alt_min]))


### PR DESCRIPTION
When running the same schedule with what appear to be the same versions for basically all packages (`scheduler`, `scheduler-scripts`, `SAT-scan-schedules`, `numpy`, `ocs`, `socs`, etc) there is a difference in when some scans are considered sun-safe between running on site and running on my Mac with the latter being more restrictive by a few minutes.  This reduces the refresh rate of the sun safety tracker to one hour instead of 6, which makes the site agree with my Mac.

Also makes the gap finding re-use the same sun tracker object when possible.  Won't be a big improvement for most cases, but when we run into sun-safety difficulties, this can speed that part of the code up by a large factor.

Example config where this problem occurs:

```
platform: satp3

# yaml loads iso format automatically into datetimes
t0: 2025-09-30T16:00:00+00:00
t1: 2025-10-01T16:00:00+00:00
t0_state_file: None
t0_state_file: /so/home/mmccrackan/so/scheduler/20250923_satp3_test/scheduler-scripts/sat/satp3/state_files/state_2025-09-30T16:00:00+00:00.npy

elevation: 60
boresight: 0
az_speed: 0.5
az_accel: 0.25
min_hwp_el: 48

# optional, only needed if running non-defaults
apply_boresight_rotation: False
disable_hwp: False
brake_hwp: False
no_cmb: False
#hwp_override: True # True: positive frequency, False: negative frequency
az_motion_override: True # True: overwrite azspeed as set above, False: use azspeed written in the master schedule.
relock_cadence: 86400 # Relock every 24 hours
home_at_end: False # If true spin down HWP and go to (180,40), otherwise scheduler will find a sun-safe parking spot and go there until the end of the specified time-frame.
bias_step_cadence: 1800
use_cal_file: False # If true scheduler will find plant observations from planet cal files
use_wiregrid_file: True
wiregrid_el: 60

# can comment out completely if only wanting CMB
# BE CAREFUL - scheduler does not spin down HWP for boresight rotations 
#              in cal targets. Probably best not to use them
cal_targets:
  - source: moon
    # boresight: # if not specified, use scan boresight
    elevation: 55
    focus: 'ws6'
    allow_partial: False
  #  az_branch: 270 ## maybe need to scan one side of jupiter
  #- source: moon
    # boresight: # if not specified, use scan boresight
    #elevation: 60
    #focus: 'ws1'
    #allow_partial: False
```