### PR TITLE
Round timestamps in sun-safety checking

### DIFF
--- a/src/schedlib/policies/stages/build_op.py
+++ b/src/schedlib/policies/stages/build_op.py
@@ -38,7 +38,10 @@ def get_traj(az0, az1, el0, el1, wrap_north=False):
 def get_traj_ok_time(az0, az1, alt0, alt1, t0, sun_policy, block0=None):
     # Returns the timestamp until which the move from
     # (az0, alt0) to (az1, alt1) is sunsafe.
-    sun_tracker = get_sun_tracker(u.dt2ct(t0), policy=sun_policy)
+
+    t0 = np.round(t0.timestamp(), 1)
+
+    sun_tracker = get_sun_tracker(t0, policy=sun_policy)
 
     if block0 is not None and hasattr(block0, 'block'):
         block0 = block0.block
@@ -60,12 +63,12 @@ def get_traj_ok_time(az0, az1, alt0, alt1, t0, sun_policy, block0=None):
             el1 = (az[:,None]*0 + el[None,:]).ravel()
             az, el = az1, el1
 
-    sun_safety = sun_tracker.check_trajectory(t=u.dt2ct(t0), az=az, el=el)
+    sun_safety = sun_tracker.check_trajectory(t=t0, az=az, el=el)
     if (sun_safety['sun_time'] <= sun_policy['min_sun_time']
         or sun_safety['sun_dist_min'] <= sun_policy['min_angle']):
-        return t0
+        return u.ct2dt(t0)
 
-    return u.ct2dt(u.dt2ct(t0) + sun_safety['sun_time'])
+    return u.ct2dt(t0 + sun_safety['sun_time'])
 
 def get_socs_policy(sun_policy):
     policy = avoidance.DEFAULT_POLICY
@@ -85,7 +88,7 @@ def get_traj_ok_time_socs_scan(az0, az1, alt0, alt1, t0, sun_policy, block0=None
     # returns t0 if no move could be found
     policy = get_socs_policy(sun_policy)
 
-    t0 = t0.timestamp()
+    t0 = np.round(t0.timestamp(), 1)
 
     if block0 is not None and hasattr(block0, 'block'):
         subtype = block0.subtype
@@ -143,7 +146,7 @@ def get_traj_ok_time_socs_move(az0, az1, alt0, alt1, t0, sun_policy, block0=None
     # returns t0 if no move could be found
     policy = get_socs_policy(sun_policy)
 
-    t0 = t0.timestamp()
+    t0 = np.round(t0.timestamp(), 1)
 
     if block0 is not None and hasattr(block0, 'block'):
         subtype = block0.subtype


### PR DESCRIPTION
A 0.03 second difference between the times inside of `scheduler` and the times written in the output schedules resulted in a sun-safety error for SATp2.  This just rounds the times inside of the sun-safety checking functions so they agree with the latter.