### PR TITLE
Truncate instead of rounding

### DIFF
--- a/src/schedlib/policies/stages/build_op.py
+++ b/src/schedlib/policies/stages/build_op.py
@@ -39,7 +39,7 @@ def get_traj_ok_time(az0, az1, alt0, alt1, t0, sun_policy, block0=None):
     # Returns the timestamp until which the move from
     # (az0, alt0) to (az1, alt1) is sunsafe.
 
-    t0 = t0.isoformat(timespec='seconds') #np.round(t0.timestamp(), 1)
+    t0 = t0.isoformat(timespec='seconds')
     t0 = dt.datetime.fromisoformat(t0).timestamp()
 
     sun_tracker = get_sun_tracker(t0, policy=sun_policy)

--- a/src/schedlib/policies/stages/build_op.py
+++ b/src/schedlib/policies/stages/build_op.py
@@ -39,7 +39,8 @@ def get_traj_ok_time(az0, az1, alt0, alt1, t0, sun_policy, block0=None):
     # Returns the timestamp until which the move from
     # (az0, alt0) to (az1, alt1) is sunsafe.
 
-    t0 = np.round(t0.timestamp(), 1)
+    t0 = t0.isoformat(timespec='seconds') #np.round(t0.timestamp(), 1)
+    t0 = dt.datetime.fromisoformat(t0).timestamp()
 
     sun_tracker = get_sun_tracker(t0, policy=sun_policy)
 
@@ -88,7 +89,8 @@ def get_traj_ok_time_socs_scan(az0, az1, alt0, alt1, t0, sun_policy, block0=None
     # returns t0 if no move could be found
     policy = get_socs_policy(sun_policy)
 
-    t0 = np.round(t0.timestamp(), 1)
+    t0 = t0.isoformat(timespec='seconds')
+    t0 = dt.datetime.fromisoformat(t0).timestamp()
 
     if block0 is not None and hasattr(block0, 'block'):
         subtype = block0.subtype
@@ -146,7 +148,8 @@ def get_traj_ok_time_socs_move(az0, az1, alt0, alt1, t0, sun_policy, block0=None
     # returns t0 if no move could be found
     policy = get_socs_policy(sun_policy)
 
-    t0 = np.round(t0.timestamp(), 1)
+    t0 = t0.isoformat(timespec='seconds')
+    t0 = dt.datetime.fromisoformat(t0).timestamp()
 
     if block0 is not None and hasattr(block0, 'block'):
         subtype = block0.subtype


### PR DESCRIPTION
#298 fixed issues with SATp2 but caused problems with the LAT.  This now duplicates exactly what is done in the sun-safety checker so the times should be consistent.