### PR TITLE
change minimum elevation of wiregrid operation

### DIFF
--- a/src/schedlib/policies/sat.py
+++ b/src/schedlib/policies/sat.py
@@ -315,7 +315,7 @@ def bias_step(state, block, bias_step_cadence=None):
     return tel.bias_step(state, block, bias_step_cadence)
 
 @cmd.operation(name='sat.wiregrid', return_duration=True)
-def wiregrid(state, block, min_wiregrid_el=47.5):
+def wiregrid(state, block, min_wiregrid_el=49.9):
     assert state.hwp_spinning == True, "hwp is not spinning"
     assert block.alt >= min_wiregrid_el, f"Block {block} is below the minimum wiregrid elevation of {min_wiregrid_el} degrees."
 
@@ -381,7 +381,7 @@ class SATPolicy(tel.TelPolicy):
     max_hwp_el: float = 60 # deg
     boresight_override: Optional[float] = None
     wiregrid_az: float = 180
-    wiregrid_el: float = 48
+    wiregrid_el: float = 50
 
     def apply_overrides(self, blocks):
         if self.boresight_override is not None:

--- a/src/schedlib/policies/satp1.py
+++ b/src/schedlib/policies/satp1.py
@@ -202,7 +202,7 @@ def make_config(
     allow_partial_override=False,
     drift_override=True,
     wiregrid_az=180,
-    wiregrid_el=48,
+    wiregrid_el=50,
     **op_cfg
 ):
     blocks = make_blocks(master_file, 'sat-cmb')
@@ -335,7 +335,7 @@ class SATP1Policy(SATPolicy):
         allow_partial_override=False,
         drift_override=True,
         wiregrid_az=180,
-        wiregrid_el=60,
+        wiregrid_el=50,
         **op_cfg
     ):
         if cal_targets is None:

--- a/src/schedlib/policies/satp2.py
+++ b/src/schedlib/policies/satp2.py
@@ -202,7 +202,7 @@ def make_config(
     allow_partial_override=False,
     drift_override=True,
     wiregrid_az=180,
-    wiregrid_el=48,
+    wiregrid_el=50,
     **op_cfg
 ):
     blocks = make_blocks(master_file, 'sat-cmb')
@@ -336,7 +336,7 @@ class SATP2Policy(SATPolicy):
         allow_partial_override=False,
         drift_override=True,
         wiregrid_az=180,
-        wiregrid_el=48,
+        wiregrid_el=50,
         **op_cfg
     ):
         if cal_targets is None:

--- a/src/schedlib/policies/satp3.py
+++ b/src/schedlib/policies/satp3.py
@@ -207,7 +207,7 @@ def make_config(
     allow_partial_override=False,
     drift_override=True,
     wiregrid_az=180,
-    wiregrid_el=48,
+    wiregrid_el=50,
     **op_cfg
 ):
     blocks = make_blocks(master_file, 'sat-cmb')
@@ -345,7 +345,7 @@ class SATP3Policy(SATPolicy):
         allow_partial_override=False,
         drift_override=True,
         wiregrid_az=180,
-        wiregrid_el=48,
+        wiregrid_el=50,
         **op_cfg
     ):
         if cal_targets is None:


### PR DESCRIPTION
This PR change minimum elevation of wiregrid operation and default elevation values since wiregird can operate 50 < El < 60.
Current main branch make wiregrid opearation at elevation of 48 as a default when we make a schedule manually.