### PR TITLE
Use ref plan az_speed

### DIFF
--- a/src/schedlib/policies/lat.py
+++ b/src/schedlib/policies/lat.py
@@ -534,8 +534,7 @@ class LATPolicy(tel.TelPolicy):
         )
         blocks = core.seq_map(
             lambda b: b.replace(
-                az_speed=round( self.az_speed/np.cos(np.radians(b.alt if b.alt <= 90 else 180 - b.alt)),2),
-                az_accel=self.az_accel,
+                az_speed=round( b.az_speed/np.cos(np.radians(b.alt if b.alt <= 90 else 180 - b.alt)),2),
             ), blocks
         )
 


### PR DESCRIPTION
Now that the LAT reference plans have `az_speed` and `az_accel` in the m, this updates the LAT to default to the az speed and accel in the ref plan instead of the one specified at command line unless `az_motion_override` is `True`.