### PR TITLE
Reason 153 we should get these out into version controlled config files

### DIFF
--- a/src/schedlib/policies/satp1.py
+++ b/src/schedlib/policies/satp1.py
@@ -222,7 +222,7 @@ def make_config(
     sun_policy = {
         'min_angle': 41,
         'min_sun_time': 1980,
-        'min_el': 48,
+        'min_el': 40,
         'max_el': 90,
         'min_az': -45,
         'max_az': 405,


### PR DESCRIPTION
I believe this explains the error we had from the satp1 schedule today when I added the new lower el calibration scans