### PR TITLE
Unify detector setup commands

### DIFF
--- a/src/schedlib/policies/satp3.py
+++ b/src/schedlib/policies/satp3.py
@@ -11,41 +11,7 @@ class SATP3Policy(SATPolicy):
     platform: str = "satp3"
 
     def __post_init__(self):
-        if self.boresight_override is not None:
-            logger.warning("Boresight Override does nothing for SATp3")
-            self.boresight_override = None
-
-        cmds_uxm_relock = [
-            "",
-            "####################### Relock #######################",
-            "run.smurf.zero_biases()",
-            "time.sleep(120)",
-            "run.smurf.uxm_relock(concurrent=True)",
-            "################## Relock Over #######################",
-            "",
-        ]
-
-        cmds_det_setup = [
-            "",
-            "################### Detector Setup######################",
-            "with disable_trace():",
-            "    run.initialize()",
-            "run.smurf.iv_curve(concurrent=True)",
-            "run.smurf.bias_dets(rfrac=0.5, concurrent=True)",
-            "time.sleep(300)",
-            "run.smurf.bias_step(concurrent=True)",
-            "#################### Detector Setup Over ####################",
-            "",
-        ]
-
-        self.blocks = self.make_blocks('sat-cmb')
-        self.geometries = self.make_geometry()
-        self.operations = self.make_operations(cmds_uxm_relock=cmds_uxm_relock, cmds_det_setup=cmds_det_setup)
-
-        if self.elevation_override is not None:
-            self.stages["build_op"]["plan_moves"]["el_limits"] = 2*[self.elevation_override]
-        elif self.force_max_hwp_el and self.max_hwp_el is not None:
-            self.stages["build_op"]["plan_moves"]["el_limits"][1] = self.max_hwp_el
+        super().__post_init__()
 
     def add_cal_target(self, *args, **kwargs):
         array_focus = {

--- a/src/schedlib/policies/tel.py
+++ b/src/schedlib/policies/tel.py
@@ -217,9 +217,8 @@ def det_setup(
                 "run.smurf.iv_curve(concurrent=True, ",
                 "    iv_kwargs={'run_serially': False, 'cool_wait': 60*5})",
                 "run.smurf.bias_dets(concurrent=True)",
-                "time.sleep(180)",
+                "time.sleep(300)",
                 "run.smurf.bias_step(concurrent=True)",
-                "run.smurf.take_noise(concurrent=True, tag='bias_check')",
                 "#################### Detector Setup Over ####################",
                 "",
             ]


### PR DESCRIPTION
Removes SATp3's det setup and relock commands.
Removes `take_noise` from detector setup.
Increases wait time to 300 seconds after `bias_dets`.