### PR TITLE
Ys/relock wihtin sunbreak 1222

### DIFF
--- a/src/schedlib/instrument.py
+++ b/src/schedlib/instrument.py
@@ -262,6 +262,11 @@ class StareBlock(ScanBlock):
 
         return t, t*0+self.az, t*0+self.alt
 
+@dataclass(frozen=True)
+class NoObsBlock(StareBlock):
+    subtype: str = "noobs"
+    priority: float = 20
+    
 # dummy type variable for readability
 Spec = TypeVar('Spec')
 SpecsTree = Dict[str, Union[Spec, "SpecsTree"]]
@@ -493,6 +498,17 @@ def parse_sequence_from_toast_sat(ifile):
                 priority=row['priority'],
                 tag=_escape_string(row['uid'].strip()),
                 hwp_dir=(row['hwp_dir'] == 1) if 'hwp_dir' in row else None
+            )
+            blocks.append(block)
+        else: # For NO OBSERVATION Block
+            block = NoObsBlock(
+                name=_escape_string(row['patch'].strip()),
+                t0=u.str2datetime(row['start_utc']),
+                t1=u.str2datetime(row['stop_utc']),
+                az=row['az_min'],
+                alt=row['el'],
+                subtype='noobs',
+                priority=20
             )
             blocks.append(block)
     return blocks

--- a/src/schedlib/policies/stages/build_op.py
+++ b/src/schedlib/policies/stages/build_op.py
@@ -856,7 +856,7 @@ class BuildOpSimple:
 
         # for how long is this block sun-safe
         _, sun_safe, _ = get_traj_ok_time_socs(block.az, block.az, block.alt, block.alt, block.t1,
-                                       self.plan_moves['sun_policy'], block0=block, return_all=True)
+                                    self.plan_moves['sun_policy'], block0=block, return_all=True)
         final_safet = u.ct2dt(u.dt2ct(block.t1) + sun_safe['sun_time'])
 
         initial_state = state


### PR DESCRIPTION
This pr add functions to use 'NO OBSERVATION' column in cmb reference plan.
Relock can be run during it, so I added functions to have relock within it. We can choose `run_relock_noobs` and set `relock_cadence_noobs` in a yaml file for making a schedule with scheduler-scripts.
We need https://github.com/simonsobs/scheduler-scripts/pull/67 for replacing elevation of 'NO OBSERVATION' block.