### PR TITLE
Update noobs priority

### DIFF
--- a/src/schedlib/policies/sat.py
+++ b/src/schedlib/policies/sat.py
@@ -991,7 +991,7 @@ class SATPolicy(tel.TelPolicy):
                     'pre': noobs_pre,
                     'in': [],
                     'post': noobs_post,
-                    'priority': 20,
+                    'priority': 0,
                     'pinned': True
                 }
             else:


### PR DESCRIPTION
Sets `NoObs` priority to highest CMB priority due to sun-avoidance problem with moving too to next CMB block early when the wiregrid is enabled.