### PR TITLE
Add ASO tubes

### DIFF
--- a/src/schedlib/policies/lat.py
+++ b/src/schedlib/policies/lat.py
@@ -271,24 +271,45 @@ class LATPolicy(tel.TelPolicy):
         logger.info(f"making geometry with xi offset={self.xi_offset}, eta offset={self.eta_offset}")
         radius = 0.3
         return {
-            "c1_ws0": {"center": [-0.3710+self.xi_offset, 0.0000+self.eta_offset], "radius": radius,},
-            "c1_ws1": {"center": [ 0.1815+self.xi_offset, 0.3211+self.eta_offset], "radius": radius,},
-            "c1_ws2": {"center": [ 0.1815+self.xi_offset, -0.3211+self.eta_offset], "radius": radius,},
-            "i1_ws0": {"center": [-1.9112+self.xi_offset, -0.9052+self.eta_offset], "radius": radius,},
-            "i1_ws1": {"center": [-1.3584+self.xi_offset, -0.5704+self.eta_offset], "radius": radius,},
-            "i1_ws2": {"center": [-1.3587+self.xi_offset, -1.2133+self.eta_offset], "radius": radius,},
-            "i3_ws0": {"center": [ 1.1865+self.xi_offset, -0.8919+self.eta_offset], "radius": radius,},
-            "i3_ws1": {"center": [ 1.7326+self.xi_offset, -0.5705+self.eta_offset], "radius": radius,},
-            "i3_ws2": {"center": [ 1.7333+self.xi_offset, -1.2135+self.eta_offset], "radius": radius,},
-            "i4_ws0": {"center": [ 1.1732+self.xi_offset, 0.9052+self.eta_offset], "radius": radius,},
-            "i4_ws1": {"center": [ 1.7332+self.xi_offset, 1.2135+self.eta_offset], "radius": radius,},
-            "i4_ws2": {"center": [ 1.7326+self.xi_offset, 0.5705+self.eta_offset], "radius": radius,},
-            "i5_ws0": {"center": [-0.3655+self.xi_offset, 1.7833+self.eta_offset], "radius": radius,},
-            "i5_ws1": {"center": [ 0.1879+self.xi_offset, 2.1045+self.eta_offset], "radius": radius,},
-            "i5_ws2": {"center": [ 0.1867+self.xi_offset, 1.4620+self.eta_offset], "radius": radius,},
-            "i6_ws0": {"center": [-1.9082+self.xi_offset, 0.8920+self.eta_offset], "radius": radius,},
-            "i6_ws1": {"center": [-1.3577+self.xi_offset, 1.2133+self.eta_offset], "radius": radius,},
-            "i6_ws2": {"center": [-1.3584+self.xi_offset, 0.5854+self.eta_offset], "radius": radius,},
+            "c1_ws0": {"center": [-0.3710+self.xi_offset, 0.0000+self.eta_offset], "radius": radius,}, # uhf
+            "c1_ws1": {"center": [ 0.1815+self.xi_offset, 0.3211+self.eta_offset], "radius": radius,}, # uhf
+            "c1_ws2": {"center": [ 0.1815+self.xi_offset, -0.3211+self.eta_offset], "radius": radius,}, # uhf
+            "i1_ws0": {"center": [-1.9112+self.xi_offset, -0.9052+self.eta_offset], "radius": radius,}, # mf
+            "i1_ws1": {"center": [-1.3584+self.xi_offset, -0.5704+self.eta_offset], "radius": radius,}, # mf
+            "i1_ws2": {"center": [-1.3587+self.xi_offset, -1.2133+self.eta_offset], "radius": radius,}, # mf
+            "i2_ws0": {"center": [-0.36415+self.xi_offset, -1.78324+self.eta_offset], "radius": radius,}, # uhf
+            "i2_ws1": {"center": [0.18876+self.xi_offset, -1.46305+self.eta_offset], "radius": radius,}, # uhf
+            "i2_ws2": {"center": [0.19272+self.xi_offset, -2.10348+self.eta_offset], "radius": radius,}, # uhf
+            "i3_ws0": {"center": [ 1.1865+self.xi_offset, -0.8919+self.eta_offset], "radius": radius,}, # mf
+            "i3_ws1": {"center": [ 1.7326+self.xi_offset, -0.5705+self.eta_offset], "radius": radius,}, # mf
+            "i3_ws2": {"center": [ 1.7333+self.xi_offset, -1.2135+self.eta_offset], "radius": radius,}, # mf
+            "i4_ws0": {"center": [ 1.1732+self.xi_offset, 0.9052+self.eta_offset], "radius": radius,}, # mf
+            "i4_ws1": {"center": [ 1.7332+self.xi_offset, 1.2135+self.eta_offset], "radius": radius,}, # mf
+            "i4_ws2": {"center": [ 1.7326+self.xi_offset, 0.5705+self.eta_offset], "radius": radius,}, # mf
+            "i5_ws0": {"center": [-0.3655+self.xi_offset, 1.7833+self.eta_offset], "radius": radius,}, # uhf
+            "i5_ws1": {"center": [ 0.1879+self.xi_offset, 2.1045+self.eta_offset], "radius": radius,}, # uhf
+            "i5_ws2": {"center": [ 0.1867+self.xi_offset, 1.4620+self.eta_offset], "radius": radius,}, # uhf
+            "i6_ws0": {"center": [-1.9082+self.xi_offset, 0.8920+self.eta_offset], "radius": radius,}, # mf
+            "i6_ws1": {"center": [-1.3577+self.xi_offset, 1.2133+self.eta_offset], "radius": radius,}, # mf
+            "i6_ws2": {"center": [-1.3584+self.xi_offset, 0.5854+self.eta_offset], "radius": radius,}, # mf
+            "o1_ws0": {"center": [-1.89594+self.xi_offset, -2.67462+self.eta_offset], "radius": radius,}, # uhf
+            "o1_ws1": {"center": [-1.34547+self.xi_offset, -2.35298+self.eta_offset], "radius": radius,}, # uhf
+            "o1_ws2": {"center": [-1.33923+self.xi_offset, -2.99545+self.eta_offset], "radius": radius,}, # uhf
+            "o2_ws0": {"center": [1.18755+self.xi_offset, -2.67467+self.eta_offset], "radius": radius,}, # mf
+            "o2_ws1": {"center": [1.74466+self.xi_offset, -2.35369+self.eta_offset], "radius": radius,}, # mf
+            "o2_ws2": {"center": [1.75046+self.xi_offset, -2.99649+self.eta_offset], "radius": radius,}, # mf
+            "o3_ws0": {"center": [2.73022+self.xi_offset, 2e-05+self.eta_offset], "radius": radius,}, # mf
+            "o3_ws1": {"center": [3.2929+self.xi_offset, 0.32195+self.eta_offset], "radius": radius,}, # mf
+            "o3_ws2": {"center": [3.2929+self.xi_offset, -0.32193+self.eta_offset], "radius": radius,}, # mf
+            "o4_ws0": {"center": [1.18755+self.xi_offset, 2.6747+self.eta_offset], "radius": radius,}, # mf
+            "o4_ws1": {"center": [1.75045+self.xi_offset, 2.99652+self.eta_offset], "radius": radius,}, # mf
+            "o4_ws2": {"center": [1.74467+self.xi_offset, 2.35372+self.eta_offset], "radius": radius,}, # mf
+            "o5_ws0": {"center": [-1.89594+self.xi_offset, 2.67466+self.eta_offset], "radius": radius,}, # mf
+            "o5_ws1": {"center": [-1.33923+self.xi_offset, 2.99547+self.eta_offset], "radius": radius,}, # mf
+            "o5_ws2": {"center": [-1.34546+self.xi_offset, 2.353+self.eta_offset], "radius": radius,}, # mf
+            "o6_ws0": {"center": [-3.43694+self.xi_offset, 2e-05+self.eta_offset], "radius": radius,}, # lf
+            "o6_ws1": {"center": [-2.88688+self.xi_offset, 0.32179+self.eta_offset], "radius": radius,}, # lf
+            "o6_ws2": {"center": [-2.88688+self.xi_offset, -0.32176+self.eta_offset], "radius": radius,}, # lf
         }
 
     def make_operations(self):
@@ -827,12 +848,19 @@ class LATPolicy(tel.TelPolicy):
         source_direction=None
     ):
         array_focus = {
-            'c1': 'c1_ws0,c1_ws1,c1_ws2',
-            'i1': 'i1_ws0,i1_ws1,i1_ws2',
-            'i3': 'i3_ws0,i3_ws1,i3_ws2',
-            'i4': 'i4_ws0,i4_ws1,i4_ws2',
-            'i5': 'i5_ws0,i5_ws1,i5_ws2',
-            'i6': 'i6_ws0,i6_ws1,i6_ws2',
+            'c1': 'c1_ws0,c1_ws1,c1_ws2', # uhf
+            'i1': 'i1_ws0,i1_ws1,i1_ws2', # mf
+            'i2': 'i2_ws0,i2_ws1,i2_ws2', # uhf
+            'i3': 'i3_ws0,i3_ws1,i3_ws2', # mf
+            'i4': 'i4_ws0,i4_ws1,i4_ws2', # mf
+            'i5': 'i5_ws0,i5_ws1,i5_ws2', # uhf
+            'i6': 'i6_ws0,i6_ws1,i6_ws2', # mf
+            'o1': 'o1_ws0,o1_ws1,o1_ws2', # uhf
+            'o2': 'o2_ws0,o2_ws1,o2_ws2', # mf
+            'o3': 'o3_ws0,o3_ws1,o3_ws2', # mf
+            'o4': 'o4_ws0,o4_ws1,o4_ws2', # mf
+            'o5': 'o5_ws0,o5_ws1,o5_ws2', # mf
+            'o6': 'o6_ws0,o6_ws1,o6_ws2', # lf
         }
 
         elevation = float(elevation)

--- a/src/schedlib/policies/tel.py
+++ b/src/schedlib/policies/tel.py
@@ -415,7 +415,7 @@ class TelPolicy:
     az_offset: float = 0.0 # deg
     el_offset: float = 0.0 # deg
     xi_offset: float = 0.0 # deg
-    eta_offset: float = 0.0 #deg
+    eta_offset: float = 0.0 # deg
     az_motion_override: bool = False
     elevation_override: bool = False
     el_mode_override: str = ''


### PR DESCRIPTION
Closes #342

Adds the ASO tubes for the LAT, using:

https://github.com/simonsobs/pwg-scripts/blob/9525f276fed179f6c2539ecd5f39d356b6c6ee6d/pwg-bcp/focalplane/latr_ot_optics.py#L4

https://simonsobs.atlassian.net/wiki/spaces/PRO/pages/101974017/Focal+Plane+Coordinates#Data-Files

<img width="764" height="574" alt="image" src="https://github.com/user-attachments/assets/72513c80-1909-401d-b987-e7bd1f2aac87" />

Confirmed it matches the orientations (with -120 deg rotation) to slides on https://simonsobs.atlassian.net/wiki/spaces/ASO/pages/255557670/3.02.06+-+OT+Integration