### PR TITLE
Don't run det setup if too short

### DIFF
--- a/src/schedlib/policies/sat.py
+++ b/src/schedlib/policies/sat.py
@@ -986,7 +986,7 @@ class SATPolicy(tel.TelPolicy):
                     'pre': cmb_pre,
                     'in': cmb_in,
                     'post': cmb_post,
-                    'priority': block.priority
+                    'priority': 0, #block.priority
                 }
             elif block.subtype == 'wiregrid':
                 return {

--- a/src/schedlib/policies/stages/build_op.py
+++ b/src/schedlib/policies/stages/build_op.py
@@ -848,6 +848,12 @@ class BuildOpSimple:
             logger.info(f"--> skipping block {block.name} because it's already past")
             return state, []
 
+        if block.t1 > constraint.t1:
+            block = block.trim_right_to(constraint.t1)
+
+        if block is None:
+            return state, []
+
         shift = 10
         safet = get_traj_ok_time(block.az, block.az, block.alt, block.alt, state.curr_time, self.plan_moves['sun_policy'])
         while safet <= state.curr_time:

--- a/src/schedlib/policies/tel.py
+++ b/src/schedlib/policies/tel.py
@@ -180,7 +180,8 @@ def det_setup(
         commands=None,
         apply_rot=True,
         iv_cadence=None,
-        det_setup_duration=20*u.minute
+        det_setup_duration=20*u.minute,
+        min_cmb_duration=10*u.minute,
     ):
     # when should det setup be done?
     # -> should always be done if the block is a cal block
@@ -205,7 +206,11 @@ def det_setup(
             )
         if iv_cadence is not None:
             time_since_last = (state.curr_time - state.last_iv).total_seconds()
-            doit = doit or (time_since_last > iv_cadence)
+            if not doit:
+                # if not running det_setup for any other reason than cadence, skip it if the scan is too short
+                doit = (time_since_last > iv_cadence) and (state.curr_time + dt.timedelta(seconds=det_setup_duration) <= (block.t1 - dt.timedelta(seconds=min_cmb_duration)))
+            else:
+                doit = doit or (time_since_last > iv_cadence)
 
     if doit:
         if commands is None:


### PR DESCRIPTION
If a det setup is only being run due to the cadence (i.e detectors are set up, no boresight rotation or elevation change and not a cal observation) and the scan is too short, do not run detector setup and just run the scan as is.  This will catch cases where a remainder scan (~10-20 min) will want to do a detector setup, but will get completely cut leaving an empty spot.  It should not be possible to get several of these cases in a row.

Also trims the ends of the blocks to the constraint if they go beyond it.  Previously, the block was only cut after pre-ops were calculated, so the above detector setup could still get scheduled.