### PR TITLE
Add initialize before relocks

### DIFF
--- a/src/schedlib/policies/satp3.py
+++ b/src/schedlib/policies/satp3.py
@@ -18,6 +18,8 @@ class SATP3Policy(SATPolicy):
         cmds_uxm_relock = [
             "",
             "####################### Relock #######################",
+            "with disable_trace():",
+            "    run.initialize()",
             "run.smurf.zero_biases()",
             "time.sleep(120)",
             "run.smurf.uxm_relock(concurrent=True)",

--- a/src/schedlib/policies/tel.py
+++ b/src/schedlib/policies/tel.py
@@ -163,6 +163,8 @@ def ufm_relock(state, commands=None, relock_cadence=24*u.hour):
             commands = [
                 "",
                 "####################### Relock #######################",
+                "with disable_trace():",
+                "    run.initialize()",
                 "run.smurf.zero_biases()",
                 "time.sleep(120)",
                 "run.smurf.uxm_relock(concurrent=True)",


### PR DESCRIPTION
Since relocks occur anywhere in schedules nowadays, it makes sense to re initialize before we do them.