### PR TITLE
Always set scan params

### DIFF
--- a/src/schedlib/commands.py
+++ b/src/schedlib/commands.py
@@ -355,19 +355,14 @@ def start_time(state):
 @operation(name='set_scan_params', duration=0)
 def set_scan_params(state, az_speed, az_accel, el_freq=0, az_motion_override=False, el_mode_override=None):
     cmds = []
-    if (
-        az_speed != state.az_speed_now
-        or az_accel != state.az_accel_now
-        or el_freq != state.el_freq_now
-    ):
-        state = state.replace(az_speed_now=az_speed, az_accel_now=az_accel, el_freq_now=el_freq)
-        args = [
-            f"az_speed={az_speed}",
-            f"az_accel={az_accel}",
-            f"el_freq={el_freq}"
-        ]
-    else:
-        args = []
+
+    state = state.replace(az_speed_now=az_speed, az_accel_now=az_accel, el_freq_now=el_freq)
+
+    args = [
+        f"az_speed={az_speed}",
+        f"az_accel={az_accel}",
+        f"el_freq={el_freq}"
+    ]
 
     if el_mode_override != state.el_mode_now:
         state = state.replace(el_mode_now=el_mode_override)


### PR DESCRIPTION
Fixes a bug where `az_speed` and `az_accel` are not specified.